### PR TITLE
fix NPE in completion stage

### DIFF
--- a/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandler.java
+++ b/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandler.java
@@ -211,7 +211,7 @@ public class PaymentHandler {
                 .thenCompose(paymentOpt -> paymentOpt.map(payment -> {
                             List<UpdateAction<io.sphere.sdk.payments.Payment>> updateActions = Collections.singletonList(SetCustomField.ofObject(PAYER_ID, payerId));
                             return ctpFacade.getPaymentService().updatePayment(payment, updateActions);
-                        }).orElse(null)
+                        }).orElse(completedFuture(null))
                 );
     }
 


### PR DESCRIPTION
@lojzatran 
It was a very nasty bug :)
https://github.com/commercetools/commercetools-paypal-plus-integration/commit/2645d6#diff-99689329c2a9889010715255d37afc27R165

(if payment is not found - **null** is returned, instead of _completedFuture(null)_