### PR TITLE
80 ctp number formatting

### DIFF
--- a/src/main/java/com/commercetools/config/ApplicationConfiguration.java
+++ b/src/main/java/com/commercetools/config/ApplicationConfiguration.java
@@ -1,7 +1,5 @@
 package com.commercetools.config;
 
-import com.commercetools.helper.formatter.PaypalPlusFormatter;
-import com.commercetools.helper.formatter.impl.PaypalPlusFormatterImpl;
 import com.commercetools.pspadapter.paymentHandler.impl.PaymentHandleResponse;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -16,11 +14,6 @@ import javax.annotation.Nonnull;
 
 @Configuration
 public class ApplicationConfiguration {
-
-    @Bean
-    public PaypalPlusFormatter paypalPlusFormatter() {
-        return new PaypalPlusFormatterImpl();
-    }
 
     /**
      * @return bean which forces to treat trailing slash same as without it.

--- a/src/main/java/com/commercetools/helper/formatter/PaypalPlusFormatter.java
+++ b/src/main/java/com/commercetools/helper/formatter/PaypalPlusFormatter.java
@@ -1,5 +1,8 @@
 package com.commercetools.helper.formatter;
 
+import com.paypal.api.payments.Amount;
+import com.paypal.api.payments.Currency;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.money.MonetaryAmount;
@@ -14,5 +17,29 @@ public interface PaypalPlusFormatter {
      */
     @Nonnull
     String monetaryAmountToString(@Nullable MonetaryAmount monetaryAmount);
+
+    /**
+     * Convert string to {@link MonetaryAmount}, accepted by CTP.
+     *
+     * The parser should not be depended on fractional part, e.g. "1.00" should be parsed same as "1", "1.0", "1."
+     *
+     * @param ppAmount paypal amount in major fractional units, like [euro.cent]
+     * @param currencyCode 3 characters ISO 4217 currency code
+     * @return Parsed amount. In case of error - exception is thrown.
+     */
+    @Nonnull
+    MonetaryAmount paypalPlusAmountToCtpMonetaryAmount(@Nonnull String ppAmount, @Nonnull String currencyCode);
+
+    /**
+     * @see #paypalPlusAmountToCtpMonetaryAmount(String, String)
+     */
+    @Nonnull
+    MonetaryAmount paypalPlusAmountToCtpMonetaryAmount(@Nonnull Amount amount);
+
+    /**
+     * @see #paypalPlusAmountToCtpMonetaryAmount(String, String)
+     */
+    @Nonnull
+    MonetaryAmount paypalPlusAmountToCtpMonetaryAmount(@Nonnull Currency amount);
 
 }

--- a/src/main/java/com/commercetools/helper/formatter/impl/PaypalPlusFormatterImpl.java
+++ b/src/main/java/com/commercetools/helper/formatter/impl/PaypalPlusFormatterImpl.java
@@ -1,6 +1,10 @@
 package com.commercetools.helper.formatter.impl;
 
 import com.commercetools.helper.formatter.PaypalPlusFormatter;
+import com.paypal.api.payments.Amount;
+import com.paypal.api.payments.Currency;
+import org.javamoney.moneta.Money;
+import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -8,11 +12,12 @@ import javax.money.MonetaryAmount;
 import javax.money.format.AmountFormatQuery;
 import javax.money.format.MonetaryAmountFormat;
 import javax.money.format.MonetaryFormats;
+import java.math.BigDecimal;
 
 import static java.util.Locale.US;
 
+@Component
 public class PaypalPlusFormatterImpl implements PaypalPlusFormatter {
-
 
     /**
      * Get a formatter which converts a {@link MonetaryAmount} to a string as
@@ -57,5 +62,23 @@ public class PaypalPlusFormatterImpl implements PaypalPlusFormatter {
     @Override
     public String monetaryAmountToString(@Nullable MonetaryAmount monetaryAmount) {
         return monetaryAmount == null ? "" : getPaypalPlusMonetaryFormat().queryFrom(monetaryAmount);
+    }
+
+    @Nonnull
+    @Override
+    public MonetaryAmount paypalPlusAmountToCtpMonetaryAmount(@Nonnull String ppAmount, @Nonnull String currencyCode) {
+        return Money.of(new BigDecimal(ppAmount), currencyCode);
+    }
+
+    @Nonnull
+    @Override
+    public MonetaryAmount paypalPlusAmountToCtpMonetaryAmount(@Nonnull Amount amount) {
+        return paypalPlusAmountToCtpMonetaryAmount(amount.getTotal(), amount.getCurrency());
+    }
+
+    @Nonnull
+    @Override
+    public MonetaryAmount paypalPlusAmountToCtpMonetaryAmount(@Nonnull Currency amount) {
+        return paypalPlusAmountToCtpMonetaryAmount(amount.getValue(), amount.getCurrency());
     }
 }

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessor.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.google.gson.Gson;
 import io.sphere.sdk.payments.TransactionState;
@@ -16,8 +17,8 @@ import javax.annotation.Nonnull;
 public class PaymentSaleCompletedProcessor extends PaymentSaleNotificationProcessorBase {
 
     @Autowired
-    public PaymentSaleCompletedProcessor(@Nonnull Gson gson) {
-        super(gson);
+    public PaymentSaleCompletedProcessor(@Nonnull Gson gson, @Nonnull PaypalPlusFormatter paypalPlusFormatter) {
+        super(gson, paypalPlusFormatter);
     }
 
     @Override

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessor.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.google.gson.Gson;
 import io.sphere.sdk.payments.TransactionState;
@@ -16,8 +17,8 @@ import javax.annotation.Nonnull;
 public class PaymentSaleDeniedProcessor extends PaymentSaleNotificationProcessorBase {
 
     @Autowired
-    public PaymentSaleDeniedProcessor(@Nonnull Gson gson) {
-        super(gson);
+    public PaymentSaleDeniedProcessor(@Nonnull Gson gson, @Nonnull PaypalPlusFormatter paypalPlusFormatter) {
+        super(gson, paypalPlusFormatter);
     }
 
     @Override

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleNotificationProcessorBase.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleNotificationProcessorBase.java
@@ -1,23 +1,17 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.google.gson.Gson;
 import com.paypal.api.payments.Event;
 import io.sphere.sdk.commands.UpdateAction;
-import io.sphere.sdk.payments.Payment;
-import io.sphere.sdk.payments.Transaction;
-import io.sphere.sdk.payments.TransactionDraft;
-import io.sphere.sdk.payments.TransactionDraftBuilder;
-import io.sphere.sdk.payments.TransactionState;
-import io.sphere.sdk.payments.TransactionType;
+import io.sphere.sdk.payments.*;
 import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
-import org.javamoney.moneta.Money;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +27,11 @@ public abstract class PaymentSaleNotificationProcessorBase extends NotificationP
 
     private final static Logger logger = LoggerFactory.getLogger(PaymentSaleNotificationProcessorBase.class);
 
-    PaymentSaleNotificationProcessorBase(Gson gson) {
+    private final PaypalPlusFormatter paypalPlusFormatter;
+
+    PaymentSaleNotificationProcessorBase(@Nonnull Gson gson, @Nonnull PaypalPlusFormatter paypalPlusFormatter) {
         super(gson);
+        this.paypalPlusFormatter = paypalPlusFormatter;
     }
 
     @Nonnull
@@ -78,13 +75,14 @@ public abstract class PaymentSaleNotificationProcessorBase extends NotificationP
         try {
             Map resource = (Map) event.getResource();
             String resourceId = (String) resource.get(ID);
-            Map amount = (Map) resource.get(AMOUNT);
-            BigDecimal total = new BigDecimal((String) amount.get(TOTAL));
-            String currencyCode = (String) amount.get(CURRENCY);
             String createTime = (String) resource.get(CREATE_TIME);
 
+            Map amount = (Map) resource.get(AMOUNT);
+            String total = (String) amount.get(TOTAL);
+            String currencyCode = (String) amount.get(CURRENCY);
+
             TransactionDraft transactionDraft = TransactionDraftBuilder
-                    .of(transactionType, Money.of(total, currencyCode))
+                    .of(transactionType, paypalPlusFormatter.paypalPlusAmountToCtpMonetaryAmount(total, currencyCode))
                     .timestamp(toZonedDateTime(createTime))
                     .interactionId(resourceId)
                     .state(getExpectedTransactionState())

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessor.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.google.gson.Gson;
 import io.sphere.sdk.payments.TransactionState;
@@ -16,8 +17,8 @@ import javax.annotation.Nonnull;
 public class PaymentSalePendingProcessor extends PaymentSaleNotificationProcessorBase {
 
     @Autowired
-    public PaymentSalePendingProcessor(@Nonnull Gson gson) {
-        super(gson);
+    public PaymentSalePendingProcessor(@Nonnull Gson gson, @Nonnull PaypalPlusFormatter paypalPlusFormatter) {
+        super(gson, paypalPlusFormatter);
     }
 
     @Override

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessor.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.google.gson.Gson;
 import io.sphere.sdk.payments.TransactionState;
@@ -16,8 +17,8 @@ import javax.annotation.Nonnull;
 public class PaymentSaleRefundedProcessor extends PaymentSaleNotificationProcessorBase {
 
     @Autowired
-    public PaymentSaleRefundedProcessor(@Nonnull Gson gson) {
-        super(gson);
+    public PaymentSaleRefundedProcessor(@Nonnull Gson gson, @Nonnull PaypalPlusFormatter paypalPlusFormatter) {
+        super(gson, paypalPlusFormatter);
     }
 
     @Override

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleReversedProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleReversedProcessor.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.google.gson.Gson;
 import io.sphere.sdk.payments.TransactionState;
@@ -16,8 +17,8 @@ import javax.annotation.Nonnull;
 public class PaymentSaleReversedProcessor extends PaymentSaleNotificationProcessorBase {
 
     @Autowired
-    public PaymentSaleReversedProcessor(@Nonnull Gson gson) {
-        super(gson);
+    public PaymentSaleReversedProcessor(@Nonnull Gson gson, @Nonnull PaypalPlusFormatter paypalPlusFormatter) {
+        super(gson, paypalPlusFormatter);
     }
 
     @Override

--- a/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandlerProviderImpl.java
+++ b/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandlerProviderImpl.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.paymentHandler.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.helper.mapper.PaymentMapperHelper;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.pspadapter.facade.CtpFacadeFactory;
@@ -21,16 +22,19 @@ public class PaymentHandlerProviderImpl implements PaymentHandlerProvider {
     private final PaypalPlusFacadeFactory paypalPlusFacadeFactory;
     private final PaymentMapperHelper paymentMapperHelper;
     private final Gson paypalGson;
+    private final PaypalPlusFormatter paypalPlusFormatter;
 
     @Autowired
     public PaymentHandlerProviderImpl(@Nonnull TenantConfigFactory configFactory,
                                       @Nonnull PaypalPlusFacadeFactory paypalPlusFacadeFactory,
                                       @Nonnull PaymentMapperHelper paymentMapperHelper,
-                                      @Nonnull Gson paypalGson) {
+                                      @Nonnull Gson paypalGson,
+                                      @Nonnull PaypalPlusFormatter paypalPlusFormatter) {
         this.configFactory = configFactory;
         this.paypalPlusFacadeFactory = paypalPlusFacadeFactory;
         this.paymentMapperHelper = paymentMapperHelper;
         this.paypalGson = paypalGson;
+        this.paypalPlusFormatter = paypalPlusFormatter;
     }
 
     @Override
@@ -39,7 +43,7 @@ public class PaymentHandlerProviderImpl implements PaymentHandlerProvider {
                 .map(tenantConfig -> {
                     CtpFacade ctpFacade = new CtpFacadeFactory(tenantConfig).getCtpFacade();
                     PaypalPlusFacade payPalPlusFacade = paypalPlusFacadeFactory.getPaypalPlusFacade(tenantConfig);
-                    return new PaymentHandler(ctpFacade, paymentMapperHelper, payPalPlusFacade, tenantName, paypalGson);
+                    return new PaymentHandler(ctpFacade, paymentMapperHelper, payPalPlusFacade, tenantName, paypalGson, paypalPlusFormatter);
                 });
     }
 

--- a/src/test/java/com/commercetools/helper/formatter/impl/PaypalPlusFormatterImplTest.java
+++ b/src/test/java/com/commercetools/helper/formatter/impl/PaypalPlusFormatterImplTest.java
@@ -1,18 +1,27 @@
 package com.commercetools.helper.formatter.impl;
 
+import com.paypal.api.payments.Amount;
+import com.paypal.api.payments.Currency;
 import org.javamoney.moneta.Money;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
-@RunWith(BlockJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = PaypalPlusFormatterImpl.class)
 public class PaypalPlusFormatterImplTest {
 
-    private PaypalPlusFormatterImpl formatter = new PaypalPlusFormatterImpl();
+    @Autowired
+    private PaypalPlusFormatterImpl formatter;
 
     @Test
     public void monetaryAmountToString_simpleCases() throws Exception {
@@ -80,4 +89,91 @@ public class PaypalPlusFormatterImplTest {
         assertThat(formatter.monetaryAmountToString(Money.of(-0.275, "USD"))).isEqualTo("-0.28");
         assertThat(formatter.monetaryAmountToString(Money.of(-0.276, "USD"))).isEqualTo("-0.28");
     }
+
+
+    @Test
+    public void paypalPlusAmountToCtpMonetaryAmount_simpleCases() throws Exception {
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("0.00", "EUR")).isEqualTo(Money.of(0, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("0", "EUR")).isEqualTo(Money.of(0, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-0", "EUR")).isEqualTo(Money.of(0, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-0.0", "EUR")).isEqualTo(Money.of(0, "EUR"));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("1.00", "USD")).isEqualTo(Money.of(1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("1.0", "USD")).isEqualTo(Money.of(1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("1.", "USD")).isEqualTo(Money.of(1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("1.1", "USD")).isEqualTo(Money.of(1.1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("1.10", "USD")).isEqualTo(Money.of(1.1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("1.01", "USD")).isEqualTo(Money.of(1.01, "USD"));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-1.00", "USD")).isEqualTo(Money.of(-1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-1.0", "USD")).isEqualTo(Money.of(-1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-1.", "USD")).isEqualTo(Money.of(-1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-1.1", "USD")).isEqualTo(Money.of(-1.1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-1.10", "USD")).isEqualTo(Money.of(-1.1, "USD"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-1.01", "USD")).isEqualTo(Money.of(-1.01, "USD"));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("9.2", "UAH")).isEqualTo(Money.of(9.2, "UAH"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-8.3", "EUR")).isEqualTo(Money.of(-8.3, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("7.45", "EUR")).isEqualTo(Money.of(7.45, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-6.67", "EUR")).isEqualTo(Money.of(-6.67, "EUR"));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("99", "EUR")).isEqualTo(Money.of(99, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-98", "EUR")).isEqualTo(Money.of(-98, "EUR"));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("76.01", "EUR")).isEqualTo(Money.of(76.01, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-54.02", "EUR")).isEqualTo(Money.of(-54.02, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("48.34", "EUR")).isEqualTo(Money.of(48.34, "EUR"));
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-33.56", "EUR")).isEqualTo(Money.of(-33.56, "EUR"));
+    }
+
+    @Test
+    public void paypalPlusAmountToCtpMonetaryAmount_largeValues() throws Exception {
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("1234567890123456789", "CZK"))
+                .isEqualTo(Money.of(1234567890123456789L, "CZK"));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-1234567890123456789", "EUR")
+                .isEqualTo(Money.of(-1234567890123456789L, "EUR")));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("1234567853456785456789765456789045679.78", "USD")
+                .isEqualTo(Money.of(new BigDecimal("1234567853456785456789765456789045679.78"), "USD")));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("-65476512379468971263487132641238412984.10", "DOP")
+                .isEqualTo(Money.of(new BigDecimal("-65476512379468971263487132641238412984.1"), "DOP")));
+
+        assertThat(formatter.paypalPlusAmountToCtpMonetaryAmount("8834579872345823452354.07", "USD")
+                .isEqualTo(Money.of(new BigDecimal("8834579872345823452354.07"), "USD")));
+    }
+
+    /**
+     * Verify the overloads of
+     * {@link PaypalPlusFormatterImpl#paypalPlusAmountToCtpMonetaryAmount(java.lang.String, java.lang.String)}
+     * call this method with currency+amount arguments.
+     *
+     * While this test is success - we don't need separate test cases for the overloaded methods, since they use
+     * the same implementation.
+     */
+    @Test
+    public void paypalPlusAmountToCtpMonetaryAmount_overloads() throws Exception {
+        // verify Amount overload
+        // PaypalPlusFormatterImpl#paypalPlusAmountToCtpMonetaryAmount(com.paypal.api.payments.Amount)
+        PaypalPlusFormatterImpl spiedFormatter = spy(formatter);
+        spiedFormatter.paypalPlusAmountToCtpMonetaryAmount(new Amount("USD", "22.15"));
+        ArgumentCaptor<String> amountCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> currencyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(spiedFormatter).paypalPlusAmountToCtpMonetaryAmount(amountCaptor.capture(), currencyCaptor.capture());
+        assertThat(amountCaptor.getValue()).isEqualTo("22.15");
+        assertThat(currencyCaptor.getValue()).isEqualTo("USD");
+
+        // verify Currency overload
+        // PaypalPlusFormatterImpl#paypalPlusAmountToCtpMonetaryAmount(com.paypal.api.payments.Currency)
+        spiedFormatter = spy(formatter);
+        spiedFormatter.paypalPlusAmountToCtpMonetaryAmount(new Currency("EUR", "-45.18"));
+        amountCaptor = ArgumentCaptor.forClass(String.class);
+        currencyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(spiedFormatter).paypalPlusAmountToCtpMonetaryAmount(amountCaptor.capture(), currencyCaptor.capture());
+        assertThat(amountCaptor.getValue()).isEqualTo("-45.18");
+        assertThat(currencyCaptor.getValue()).isEqualTo("EUR");
+    }
+
+
 }

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/DefaultNotificationProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/DefaultNotificationProcessorTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.pspadapter.notification.NotificationDispatcher;
 import com.commercetools.pspadapter.notification.processor.NotificationProcessorContainer;
@@ -10,6 +11,7 @@ import com.paypal.api.payments.Event;
 import io.sphere.sdk.payments.Payment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 
@@ -26,18 +28,25 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultNotificationProcessorTest {
 
+    @Mock
+    private CtpFacade ctpFacade;
+
+    @Mock
+    private Payment payment;
+
+    @Mock
+    private PaypalPlusFormatter paypalPlusFormatter;
+
     @Test
     public void whenNotificationHasNoProcessor_defaultProcessorIsUsed() {
         Gson gson = new GsonBuilder().create();
-        CtpFacade ctpFacade = mock(CtpFacade.class);
-        Payment mockPayment = mock(Payment.class);
         DefaultNotificationProcessor mockDefaultProcessor = mock(DefaultNotificationProcessor.class);
         when(mockDefaultProcessor.processEventNotification(any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(mockPayment));
-        PaymentSaleCompletedProcessor paymentCompletedProcessor = new PaymentSaleCompletedProcessor(gson);
-        PaymentSaleRefundedProcessor paymentRefundedProcessor =new PaymentSaleRefundedProcessor(gson);
-        PaymentSaleDeniedProcessor paymentDeniedProcessor = new PaymentSaleDeniedProcessor(gson);
-        PaymentSaleReversedProcessor paymentReversedProcessor = new PaymentSaleReversedProcessor(gson);
+                .thenReturn(CompletableFuture.completedFuture(payment));
+        PaymentSaleCompletedProcessor paymentCompletedProcessor = new PaymentSaleCompletedProcessor(gson, paypalPlusFormatter);
+        PaymentSaleRefundedProcessor paymentRefundedProcessor = new PaymentSaleRefundedProcessor(gson, paypalPlusFormatter);
+        PaymentSaleDeniedProcessor paymentDeniedProcessor = new PaymentSaleDeniedProcessor(gson, paypalPlusFormatter);
+        PaymentSaleReversedProcessor paymentReversedProcessor = new PaymentSaleReversedProcessor(gson, paypalPlusFormatter);
 
         List<PaymentSaleNotificationProcessorBase> processors = Arrays.asList(paymentCompletedProcessor, paymentRefundedProcessor, paymentDeniedProcessor, paymentReversedProcessor);
 

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/DefaultNotificationProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/DefaultNotificationProcessorTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
 import com.commercetools.helper.formatter.PaypalPlusFormatter;
+import com.commercetools.helper.formatter.impl.PaypalPlusFormatterImpl;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.pspadapter.notification.NotificationDispatcher;
 import com.commercetools.pspadapter.notification.processor.NotificationProcessorContainer;
@@ -34,8 +35,7 @@ public class DefaultNotificationProcessorTest {
     @Mock
     private Payment payment;
 
-    @Mock
-    private PaypalPlusFormatter paypalPlusFormatter;
+    private PaypalPlusFormatter paypalPlusFormatter = new PaypalPlusFormatterImpl();
 
     @Test
     public void whenNotificationHasNoProcessor_defaultProcessorIsUsed() {

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessorTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -17,6 +18,7 @@ import io.sphere.sdk.payments.TransactionState;
 import io.sphere.sdk.payments.TransactionType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
@@ -36,12 +38,15 @@ public class PaymentSaleCompletedProcessorTest {
 
     private final Gson gson = new GsonBuilder().create();
 
+    @Mock
+    private PaypalPlusFormatter paypalPlusFormatter;
+
     @Test
     public void shouldRecognizeIfEventIsPaymentSaleCompleted() {
         Event event = new Event();
         event.setEventType(PAYMENT_SALE_COMPLETED.getPaypalEventTypeName());
         PaymentSaleCompletedProcessor processor
-                = new PaymentSaleCompletedProcessor(gson);
+                = new PaymentSaleCompletedProcessor(gson, paypalPlusFormatter);
         assertThat(processor.canProcess(event)).isTrue();
     }
 
@@ -57,7 +62,7 @@ public class PaymentSaleCompletedProcessorTest {
         when(mockEvent.getResource()).thenReturn(resourceMap);
 
         PaymentSaleCompletedProcessor processor
-                = new PaymentSaleCompletedProcessor(gson);
+                = new PaymentSaleCompletedProcessor(gson, paypalPlusFormatter);
 
         assertThat(processor.createUpdatePaymentActions(ctpPayment, mockEvent)).isNotEmpty();
     }
@@ -74,7 +79,7 @@ public class PaymentSaleCompletedProcessorTest {
         when(mockEvent.getResource()).thenReturn(resourceMap);
 
         PaymentSaleCompletedProcessor processor
-                = new PaymentSaleCompletedProcessor(gson);
+                = new PaymentSaleCompletedProcessor(gson, paypalPlusFormatter);
 
         assertThat(processor.createUpdatePaymentActions(ctpPayment, mockEvent)).isEmpty();
     }
@@ -87,7 +92,7 @@ public class PaymentSaleCompletedProcessorTest {
 
         Payment ctpPayment = mockCtpPayment(testInteractionId, TransactionState.PENDING);
 
-        NotificationProcessorBase processorBase = spy(new PaymentSaleCompletedProcessor(gson));
+        NotificationProcessorBase processorBase = spy(new PaymentSaleCompletedProcessor(gson, paypalPlusFormatter));
         doReturn(CompletableFuture.completedFuture(Optional.of(ctpPayment)))
                 .when(processorBase).getRelatedCtpPayment(any(), any());
         SphereClient sphereClient = mock(SphereClient.class);

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessorTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
 import com.commercetools.helper.formatter.PaypalPlusFormatter;
+import com.commercetools.helper.formatter.impl.PaypalPlusFormatterImpl;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -18,7 +19,6 @@ import io.sphere.sdk.payments.TransactionState;
 import io.sphere.sdk.payments.TransactionType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
@@ -38,8 +38,7 @@ public class PaymentSaleCompletedProcessorTest {
 
     private final Gson gson = new GsonBuilder().create();
 
-    @Mock
-    private PaypalPlusFormatter paypalPlusFormatter;
+    private PaypalPlusFormatter paypalPlusFormatter = new PaypalPlusFormatterImpl();
 
     @Test
     public void shouldRecognizeIfEventIsPaymentSaleCompleted() {

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessorTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -18,11 +19,11 @@ import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -39,6 +40,9 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("unchecked")
 public class PaymentSaleDeniedProcessorTest {
 
+    @Mock
+    private PaypalPlusFormatter paypalPlusFormatter;
+
     @Test
     public void shouldCallUpdatePaymentWithCorrectArgs() {
         // set up
@@ -46,7 +50,7 @@ public class PaymentSaleDeniedProcessorTest {
 
         Payment ctpMockPayment = createMockPayment(testInteractionId);
 
-        NotificationProcessorBase processorBase = spy(new PaymentSaleDeniedProcessor(new GsonBuilder().create()));
+        NotificationProcessorBase processorBase = spy(new PaymentSaleDeniedProcessor(new GsonBuilder().create(), paypalPlusFormatter));
 
         doReturn(CompletableFuture.completedFuture(Optional.of(ctpMockPayment)))
                 .when(processorBase).getRelatedCtpPayment(any(), any());

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessorTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
 import com.commercetools.helper.formatter.PaypalPlusFormatter;
+import com.commercetools.helper.formatter.impl.PaypalPlusFormatterImpl;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -19,7 +20,6 @@ import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -40,8 +40,7 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("unchecked")
 public class PaymentSaleDeniedProcessorTest {
 
-    @Mock
-    private PaypalPlusFormatter paypalPlusFormatter;
+    private PaypalPlusFormatter paypalPlusFormatter = new PaypalPlusFormatterImpl();
 
     @Test
     public void shouldCallUpdatePaymentWithCorrectArgs() {

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessorTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
 import com.commercetools.helper.formatter.PaypalPlusFormatter;
+import com.commercetools.helper.formatter.impl.PaypalPlusFormatterImpl;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -11,13 +12,11 @@ import com.google.gson.GsonBuilder;
 import com.paypal.api.payments.Event;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
-import io.sphere.sdk.payments.Payment;
-import io.sphere.sdk.payments.Transaction;
-import io.sphere.sdk.payments.TransactionState;
-import io.sphere.sdk.payments.TransactionType;
+import io.sphere.sdk.payments.*;
 import io.sphere.sdk.payments.commands.updateactions.AddInterfaceInteraction;
 import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
+import org.javamoney.moneta.Money;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.commercetools.payment.constants.paypalPlus.NotificationEventData.*;
 import static com.commercetools.testUtil.CompletionStageUtil.executeBlocking;
+import static io.sphere.sdk.models.DefaultCurrencyUnits.USD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
@@ -58,8 +58,7 @@ public class PaymentSalePendingProcessorTest {
     @Mock
     private OrderService orderService;
 
-    @Mock
-    private PaypalPlusFormatter paypalPlusFormatter;
+    private PaypalPlusFormatter paypalPlusFormatter = new PaypalPlusFormatterImpl();
 
     private Event event;
 
@@ -120,9 +119,12 @@ public class PaymentSalePendingProcessorTest {
             UpdateAction<Payment> addInterfaceInteractionAction = updateActions.get(0);
             assertThat(addInterfaceInteractionAction).isInstanceOf(AddInterfaceInteraction.class);
             AddTransaction addTransactionAction = (AddTransaction) updateActions.get(1);
-            assertThat(addTransactionAction.getTransaction().getType()).isEqualTo(TransactionType.CHARGE);
-            assertThat(addTransactionAction.getTransaction().getState()).isEqualTo(TransactionState.PENDING);
-            assertThat(addTransactionAction.getTransaction().getInteractionId()).isEqualTo(TEST_INTERACTION_ID);
+            TransactionDraft addedTxn = addTransactionAction.getTransaction();
+            assertThat(addedTxn.getType()).isEqualTo(TransactionType.CHARGE);
+            assertThat(addedTxn.getState()).isEqualTo(TransactionState.PENDING);
+            assertThat(addedTxn.getInteractionId()).isEqualTo(TEST_INTERACTION_ID);
+            assertThat(addedTxn.getAmount()).isEqualTo(Money.of(1, USD));
+
             return CompletableFuture.completedFuture(ctpMockPayment);
         }).when(paymentService).updatePayment(any(Payment.class), anyList());
 

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessorTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -57,6 +58,9 @@ public class PaymentSalePendingProcessorTest {
     @Mock
     private OrderService orderService;
 
+    @Mock
+    private PaypalPlusFormatter paypalPlusFormatter;
+
     private Event event;
 
     private PaymentServiceImpl paymentService;
@@ -82,7 +86,7 @@ public class PaymentSalePendingProcessorTest {
         this.ctpFacade = spy(new CtpFacade(cartService, orderService, paymentService));
         when(ctpMockPayment.getTransactions()).thenReturn(Collections.singletonList(existingCtpTransaction));
 
-        this.processorBase = spy(new PaymentSalePendingProcessor(new GsonBuilder().create()));
+        this.processorBase = spy(new PaymentSalePendingProcessor(new GsonBuilder().create(), paypalPlusFormatter));
         doReturn(CompletableFuture.completedFuture(Optional.of(ctpMockPayment)))
                 .when(processorBase).getRelatedCtpPayment(any(), any());
     }

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessorTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -17,6 +18,7 @@ import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import org.javamoney.moneta.Money;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -43,12 +45,15 @@ public class PaymentSaleRefundedProcessorTest {
 
     private static final String REFUNDED_CURRENCY = "USD";
 
+    @Mock
+    private Payment ctpMockPayment;
+
+    @Mock
+    private PaypalPlusFormatter paypalPlusFormatter;
+
     @Test
     public void shouldCallUpdatePaymentWithCorrectArgs() {
-        // set up
-        Payment ctpMockPayment = mock(Payment.class);
-
-        NotificationProcessorBase processorBase = spy(new PaymentSaleRefundedProcessor(new GsonBuilder().create()));
+        NotificationProcessorBase processorBase = spy(new PaymentSaleRefundedProcessor(new GsonBuilder().create(), paypalPlusFormatter));
 
         doReturn(CompletableFuture.completedFuture(Optional.of(ctpMockPayment)))
                 .when(processorBase).getRelatedCtpPayment(any(), any());

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessorTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
 import com.commercetools.helper.formatter.PaypalPlusFormatter;
+import com.commercetools.helper.formatter.impl.PaypalPlusFormatterImpl;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -48,8 +49,7 @@ public class PaymentSaleRefundedProcessorTest {
     @Mock
     private Payment ctpMockPayment;
 
-    @Mock
-    private PaypalPlusFormatter paypalPlusFormatter;
+    private PaypalPlusFormatter paypalPlusFormatter = new PaypalPlusFormatterImpl();
 
     @Test
     public void shouldCallUpdatePaymentWithCorrectArgs() {

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleReversedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleReversedProcessorTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
 import com.commercetools.helper.formatter.PaypalPlusFormatter;
+import com.commercetools.helper.formatter.impl.PaypalPlusFormatterImpl;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -48,8 +49,7 @@ public class PaymentSaleReversedProcessorTest {
     @Mock
     private Payment ctpMockPayment;
 
-    @Mock
-    private PaypalPlusFormatter paypalPlusFormatter;
+    private PaypalPlusFormatter paypalPlusFormatter = new PaypalPlusFormatterImpl();
 
     @Test
     public void shouldCallUpdatePaymentWithCorrectArgs() {

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleReversedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleReversedProcessorTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.notification.processor.impl;
 
+import com.commercetools.helper.formatter.PaypalPlusFormatter;
 import com.commercetools.payment.constants.paypalPlus.NotificationEventType;
 import com.commercetools.pspadapter.facade.CtpFacade;
 import com.commercetools.service.ctp.CartService;
@@ -17,6 +18,7 @@ import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import org.javamoney.moneta.Money;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -43,12 +45,15 @@ public class PaymentSaleReversedProcessorTest {
 
     private static final String REVERSED_CURRENCY = "USD";
 
+    @Mock
+    private Payment ctpMockPayment;
+
+    @Mock
+    private PaypalPlusFormatter paypalPlusFormatter;
+
     @Test
     public void shouldCallUpdatePaymentWithCorrectArgs() {
-        // set up
-        Payment ctpMockPayment = mock(Payment.class);
-
-        NotificationProcessorBase processorBase = spy(new PaymentSaleReversedProcessor(new GsonBuilder().create()));
+        NotificationProcessorBase processorBase = spy(new PaymentSaleReversedProcessor(new GsonBuilder().create(), paypalPlusFormatter));
 
         doReturn(CompletableFuture.completedFuture(Optional.of(ctpMockPayment)))
                 .when(processorBase).getRelatedCtpPayment(any(), any());


### PR DESCRIPTION
The main change:
  - extended [`PaypalPlusFormatter`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/83/files#diff-fcd47bf5d3b4afb0dee1992cdd292781) with _PP -> CTP_ formatting
  - implementation is in [`PaypalPlusFormatterImpl#paypalPlusAmountToCtpMonetaryAmount(String, String)`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/83/files#diff-2ca733d46ddfbf5ba8280297d6f51496R69)
  - updated respective tests