### PR TITLE
#56 make reverse notification to change only txn state

### DIFF
--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessor.java
@@ -28,13 +28,13 @@ public class PaymentSaleCompletedProcessor extends PaymentSaleNotificationProces
 
     @Nonnull
     @Override
-    protected TransactionType getExpectedTransactionType() {
+    protected TransactionType getCtpTransactionType() {
         return TransactionType.CHARGE;
     }
 
     @Nonnull
     @Override
-    protected TransactionState getExpectedTransactionState() {
+    protected TransactionState getCtpTransactionState() {
         return TransactionState.SUCCESS;
     }
 }

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessor.java
@@ -28,13 +28,13 @@ public class PaymentSaleDeniedProcessor extends PaymentSaleNotificationProcessor
 
     @Nonnull
     @Override
-    protected TransactionType getExpectedTransactionType() {
+    protected TransactionType getCtpTransactionType() {
         return TransactionType.CHARGE;
     }
 
     @Nonnull
     @Override
-    protected TransactionState getExpectedTransactionState() {
+    protected TransactionState getCtpTransactionState() {
         return TransactionState.FAILURE;
     }
 }

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleNotificationProcessorBase.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleNotificationProcessorBase.java
@@ -50,7 +50,7 @@ public abstract class PaymentSaleNotificationProcessorBase extends NotificationP
         String resourceId = getResourceId(event);
         return findTransactionByInteractionId(ctpPayment.getTransactions(), resourceId)
                 .map(this::processNotificationForTransaction)
-                .orElseGet(() -> createAddTransactionActionList(event, getExpectedTransactionType()));
+                .orElseGet(() -> createAddTransactionActionList(event, getCtpTransactionType()));
     }
 
     private List<UpdateAction<Payment>> processNotificationForTransaction(@Nonnull Transaction txn) {
@@ -64,13 +64,13 @@ public abstract class PaymentSaleNotificationProcessorBase extends NotificationP
     }
 
     @Nonnull
-    abstract protected TransactionType getExpectedTransactionType();
+    abstract protected TransactionType getCtpTransactionType();
 
     @Nonnull
-    abstract protected TransactionState getExpectedTransactionState();
+    abstract protected TransactionState getCtpTransactionState();
 
     protected List<UpdateAction<Payment>> createChangeTransactionStateActionList(Transaction txn) {
-        return Collections.singletonList(ChangeTransactionState.of(getExpectedTransactionState(), txn.getId()));
+        return Collections.singletonList(ChangeTransactionState.of(getCtpTransactionState(), txn.getId()));
     }
 
     protected List<UpdateAction<Payment>> createAddTransactionActionList(@Nonnull Event event,
@@ -87,7 +87,7 @@ public abstract class PaymentSaleNotificationProcessorBase extends NotificationP
                     .of(transactionType, Money.of(total, currencyCode))
                     .timestamp(toZonedDateTime(createTime))
                     .interactionId(resourceId)
-                    .state(getExpectedTransactionState())
+                    .state(getCtpTransactionState())
                     .build();
             return Collections.singletonList(AddTransaction.of(transactionDraft));
         } catch (Throwable e) {
@@ -103,6 +103,6 @@ public abstract class PaymentSaleNotificationProcessorBase extends NotificationP
     }
 
     private boolean isTxnAlreadyUpdated(Transaction txn) {
-        return txn.getType().equals(getExpectedTransactionType()) && txn.getState().equals(getExpectedTransactionState());
+        return txn.getState().equals(getCtpTransactionState());
     }
 }

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessor.java
@@ -28,13 +28,13 @@ public class PaymentSalePendingProcessor extends PaymentSaleNotificationProcesso
 
     @Nonnull
     @Override
-    protected TransactionType getExpectedTransactionType() {
+    protected TransactionType getCtpTransactionType() {
         return TransactionType.CHARGE;
     }
 
     @Nonnull
     @Override
-    protected TransactionState getExpectedTransactionState() {
+    protected TransactionState getCtpTransactionState() {
         return TransactionState.PENDING;
     }
 }

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessor.java
@@ -28,13 +28,13 @@ public class PaymentSaleRefundedProcessor extends PaymentSaleNotificationProcess
 
     @Nonnull
     @Override
-    protected TransactionType getExpectedTransactionType() {
+    protected TransactionType getCtpTransactionType() {
         return TransactionType.REFUND;
     }
 
     @Nonnull
     @Override
-    protected TransactionState getExpectedTransactionState() {
+    protected TransactionState getCtpTransactionState() {
         return TransactionState.SUCCESS;
     }
 }

--- a/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleReversedProcessor.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleReversedProcessor.java
@@ -28,13 +28,13 @@ public class PaymentSaleReversedProcessor extends PaymentSaleNotificationProcess
 
     @Nonnull
     @Override
-    protected TransactionType getExpectedTransactionType() {
-        return TransactionType.CHARGEBACK;
+    protected TransactionType getCtpTransactionType() {
+        return TransactionType.CHARGE;
     }
 
     @Nonnull
     @Override
-    protected TransactionState getExpectedTransactionState() {
-        return TransactionState.SUCCESS;
+    protected TransactionState getCtpTransactionState() {
+        return TransactionState.FAILURE;
     }
 }

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/BaseNotificationTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/BaseNotificationTest.java
@@ -1,0 +1,43 @@
+package com.commercetools.pspadapter.notification.processor.impl;
+
+import io.sphere.sdk.commands.UpdateAction;
+import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.Transaction;
+import io.sphere.sdk.payments.TransactionState;
+import io.sphere.sdk.payments.TransactionType;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
+import org.mockito.invocation.InvocationOnMock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BaseNotificationTest {
+
+    protected Payment createMockPayment(String interactionId, TransactionType txnType, TransactionState txnState) {
+        Payment ctpMockPayment = mock(Payment.class);
+        Transaction transaction = mock(Transaction.class);
+        when(ctpMockPayment.getTransactions()).thenReturn(Collections.singletonList(transaction));
+        when(transaction.getType()).thenReturn(txnType);
+        when(transaction.getState()).thenReturn(txnState);
+        when(transaction.getInteractionId()).thenReturn(interactionId);
+        return ctpMockPayment;
+    }
+
+    protected void verifyUpdatePaymentCall(Payment ctpMockPayment, InvocationOnMock invocation, TransactionState state) {
+        Payment payment = invocation.getArgumentAt(0, Payment.class);
+        List<UpdateAction<Payment>> updateActions = invocation.getArgumentAt(1, List.class);
+        assertThat(payment).isEqualTo(ctpMockPayment);
+        assertThat(updateActions.size()).isEqualTo(2);
+        // One of the action is AddInterfaceInteraction, which is common for all notification processors.
+        // I already covered this case in {PaymentSalePendingProcessorTest},
+        // so it's not necessary to repeat it here.
+        ChangeTransactionState changeTransactionState = (ChangeTransactionState) updateActions.get(1);
+        assertThat(changeTransactionState.getState()).isEqualTo(state);
+    }
+}

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleCompletedProcessorTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PaymentSaleCompletedProcessorTest {
+public class PaymentSaleCompletedProcessorTest extends BaseNotificationTest {
 
     private final Gson gson = new GsonBuilder().create();
 
@@ -49,7 +49,7 @@ public class PaymentSaleCompletedProcessorTest {
     public void whenTxnIsChargePending_shouldReturnChangeStateAction() {
         String testInteractionId = "testInteractionId";
 
-        Payment ctpPayment = mockCtpPayment(testInteractionId, TransactionState.PENDING);
+        Payment ctpPayment = createMockPayment(testInteractionId, TransactionType.CHARGE, TransactionState.PENDING);
 
         Map<String, String> resourceMap = ImmutableMap.of(ID, testInteractionId);
 
@@ -66,7 +66,7 @@ public class PaymentSaleCompletedProcessorTest {
     public void whenTxnIsChargeSuccess_shouldReturnNullChangeStateAction() {
         String testInteractionId = "testInteractionId";
 
-        Payment ctpPayment = mockCtpPayment(testInteractionId, TransactionState.SUCCESS);
+        Payment ctpPayment = createMockPayment(testInteractionId, TransactionType.CHARGE, TransactionState.SUCCESS);
 
         Map<String, String> resourceMap = ImmutableMap.of(ID, testInteractionId);
 
@@ -85,7 +85,7 @@ public class PaymentSaleCompletedProcessorTest {
         // set up
         String testInteractionId = "testInteractionId";
 
-        Payment ctpPayment = mockCtpPayment(testInteractionId, TransactionState.PENDING);
+        Payment ctpPayment = createMockPayment(testInteractionId, TransactionType.CHARGE, TransactionState.PENDING);
 
         NotificationProcessorBase processorBase = spy(new PaymentSaleCompletedProcessor(gson));
         doReturn(CompletableFuture.completedFuture(Optional.of(ctpPayment)))
@@ -114,18 +114,5 @@ public class PaymentSaleCompletedProcessorTest {
         assertThat(returnedPayment).isEqualTo(ctpPayment);
         verify(paymentService, times(1))
                 .updatePayment(any(Payment.class), anyList());
-    }
-
-    private Payment mockCtpPayment(String testInteractionId, TransactionState transactionState) {
-        Transaction transaction = mock(Transaction.class);
-        when(transaction.getType()).thenReturn(TransactionType.CHARGE);
-        when(transaction.getState()).thenReturn(transactionState);
-        when(transaction.getId()).thenReturn("testId");
-        when(transaction.getInteractionId()).thenReturn(testInteractionId);
-
-        Payment ctpPayment = mock(Payment.class);
-        when(ctpPayment.getTransactions())
-                .thenReturn(Collections.singletonList(transaction));
-        return ctpPayment;
     }
 }

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleDeniedProcessorTest.java
@@ -37,14 +37,14 @@ import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
-public class PaymentSaleDeniedProcessorTest {
+public class PaymentSaleDeniedProcessorTest extends BaseNotificationTest {
 
     @Test
     public void shouldCallUpdatePaymentWithCorrectArgs() {
         // set up
         String testInteractionId = "testInteractionId";
 
-        Payment ctpMockPayment = createMockPayment(testInteractionId);
+        Payment ctpMockPayment = createMockPayment(testInteractionId, TransactionType.CHARGE, TransactionState.PENDING);
 
         NotificationProcessorBase processorBase = spy(new PaymentSaleDeniedProcessor(new GsonBuilder().create()));
 
@@ -66,7 +66,7 @@ public class PaymentSaleDeniedProcessorTest {
 
         // test
         doAnswer(invocation -> {
-            verifyUpdatePaymentCall(ctpMockPayment, invocation);
+            verifyUpdatePaymentCall(ctpMockPayment, invocation, TransactionState.FAILURE);
             return CompletableFuture.completedFuture(ctpMockPayment);
         }).when(paymentService).updatePayment(any(Payment.class), anyList());
 
@@ -78,25 +78,4 @@ public class PaymentSaleDeniedProcessorTest {
                 .updatePayment(any(Payment.class), anyList());
     }
 
-    private Payment createMockPayment(String interactionId) {
-        Payment ctpMockPayment = mock(Payment.class);
-        Transaction transaction = mock(Transaction.class);
-        when(ctpMockPayment.getTransactions()).thenReturn(Collections.singletonList(transaction));
-        when(transaction.getState()).thenReturn(TransactionState.PENDING);
-        when(transaction.getType()).thenReturn(TransactionType.CHARGE);
-        when(transaction.getInteractionId()).thenReturn(interactionId);
-        return ctpMockPayment;
-    }
-
-    private void verifyUpdatePaymentCall(Payment ctpMockPayment, InvocationOnMock invocation) {
-        Payment payment = invocation.getArgumentAt(0, Payment.class);
-        List<UpdateAction<Payment>> updateActions = invocation.getArgumentAt(1, List.class);
-        assertThat(payment).isEqualTo(ctpMockPayment);
-        assertThat(updateActions.size()).isEqualTo(2);
-        // One of the action is AddInterfaceInteraction, which is common for all notification processors.
-        // I already covered this case in {PaymentSalePendingProcessorTest},
-        // so it's not necessary to repeat it here.
-        ChangeTransactionState changeTransactionState = (ChangeTransactionState) updateActions.get(1);
-        assertThat(changeTransactionState.getState()).isEqualTo(TransactionState.FAILURE);
-    }
 }

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSalePendingProcessorTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
-public class PaymentSalePendingProcessorTest {
+public class PaymentSalePendingProcessorTest extends BaseNotificationTest {
 
     private static final String TEST_INTERACTION_ID = "testInteractionId";
     @Mock
@@ -95,7 +95,7 @@ public class PaymentSalePendingProcessorTest {
 
         // test
         doAnswer(invocation -> {
-            verifyUpdatePaymentCall(ctpMockPayment, invocation);
+            verifyUpdatePaymentCall(ctpMockPayment, invocation, TransactionState.PENDING);
             return CompletableFuture.completedFuture(ctpMockPayment);
         }).when(paymentService).updatePayment(any(Payment.class), anyList());
 
@@ -126,18 +126,6 @@ public class PaymentSalePendingProcessorTest {
 
         // assert
         assertThat(returnedPayment).isSameAs(ctpMockPayment);
-    }
-
-    private void verifyUpdatePaymentCall(Payment ctpMockPayment, InvocationOnMock invocation) {
-        Payment payment = invocation.getArgumentAt(0, Payment.class);
-        List<UpdateAction<Payment>> updateActions = invocation.getArgumentAt(1, List.class);
-        assertThat(payment).isEqualTo(ctpMockPayment);
-        assertThat(updateActions.size()).isEqualTo(2);
-        // One of the action is AddInterfaceInteraction, which is common for all notification processors.
-        // I already covered this case in {whenTransactionIsNotFound_shouldAddNewTransaction},
-        // so it's not necessary to repeat it here.
-        ChangeTransactionState changeTransactionState = (ChangeTransactionState) updateActions.get(1);
-        assertThat(changeTransactionState.getState()).isEqualTo(TransactionState.PENDING);
     }
 
 }

--- a/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessorTest.java
+++ b/src/test/java/com/commercetools/pspadapter/notification/processor/impl/PaymentSaleRefundedProcessorTest.java
@@ -12,6 +12,7 @@ import com.paypal.api.payments.Event;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.TransactionState;
 import io.sphere.sdk.payments.TransactionType;
 import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import org.javamoney.moneta.Money;
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
-public class PaymentSaleRefundedProcessorTest {
+public class PaymentSaleRefundedProcessorTest extends BaseNotificationTest {
 
     private static final String CREATE_TIME_VALUE = "2014-10-31T15:41:51Z";
 
@@ -46,7 +47,9 @@ public class PaymentSaleRefundedProcessorTest {
     @Test
     public void shouldCallUpdatePaymentWithCorrectArgs() {
         // set up
-        Payment ctpMockPayment = mock(Payment.class);
+        String testInteractionId = "testInteractionId";
+
+        Payment ctpMockPayment = createMockPayment(testInteractionId, TransactionType.CHARGE, TransactionState.SUCCESS);
 
         NotificationProcessorBase processorBase = spy(new PaymentSaleRefundedProcessor(new GsonBuilder().create()));
 
@@ -61,7 +64,7 @@ public class PaymentSaleRefundedProcessorTest {
         );
 
         Map<String, String> amountMap = ImmutableMap.of(TOTAL, REFUNDED_AMOUNT, CURRENCY, REFUNDED_CURRENCY);
-        Map<String, Object> resourceMap = ImmutableMap.of(AMOUNT, amountMap, CREATE_TIME, CREATE_TIME_VALUE);
+        Map<String, Object> resourceMap = ImmutableMap.of(ID, testInteractionId + "_random_text", AMOUNT, amountMap, CREATE_TIME, CREATE_TIME_VALUE);
 
         Event event = new Event();
         event.setEventType(NotificationEventType.PAYMENT_SALE_REFUNDED.toString());


### PR DESCRIPTION
On reverse notification, existing `charge` txn will be updated to status `failure`.