### PR TITLE
#99: make health response optionally pretty printable

### DIFF
--- a/src/main/java/com/commercetools/controller/CommercetoolsHealthController.java
+++ b/src/main/java/com/commercetools/controller/CommercetoolsHealthController.java
@@ -1,5 +1,6 @@
 package com.commercetools.controller;
 
+import com.commercetools.http.converter.json.PrettyFormattedBody;
 import com.commercetools.model.ApplicationInfo;
 import com.commercetools.payment.handler.BaseCommercetoolsController;
 import com.commercetools.pspadapter.tenant.TenantProperties;
@@ -8,6 +9,7 @@ import org.springframework.beans.propertyeditors.StringTrimmerEditor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.Nonnull;
@@ -42,11 +44,13 @@ public class CommercetoolsHealthController extends BaseCommercetoolsController {
     @RequestMapping(
             value = {"/health", "/"},
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> checkHealth(@Autowired ApplicationInfo applicationInfo) {
+    public ResponseEntity<?> checkHealth(@RequestParam(required = false) String pretty,
+                                         @Autowired ApplicationInfo applicationInfo) {
         Map<String, Object> tenantResponse = new HashMap<>();
         tenantResponse.put("tenants", this.tenantProperties.getTenants().keySet());
         tenantResponse.put(APP_INFO_KEY, applicationInfo);
 
-        return new ResponseEntity<>(tenantResponse, HttpStatus.OK);
+        return new ResponseEntity<>(PrettyFormattedBody.of(tenantResponse, pretty != null),
+                HttpStatus.OK);
     }
 }

--- a/src/main/java/com/commercetools/http/converter/json/PrettyFormattedBody.java
+++ b/src/main/java/com/commercetools/http/converter/json/PrettyFormattedBody.java
@@ -1,0 +1,34 @@
+package com.commercetools.http.converter.json;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Class to wrap a response body if (JSON) pretty formatting could be expected in the result output.
+ */
+public final class PrettyFormattedBody {
+    private final Object body;
+    private final boolean pretty;
+
+    private PrettyFormattedBody(@Nonnull final Object body, final boolean pretty) {
+        this.body = body;
+        this.pretty = pretty;
+    }
+
+    /**
+     * @return real response body to output
+     */
+    public Object getBody() {
+        return body;
+    }
+
+    /**
+     * @return <b>true</b> if the {@link #body} should be pretty printed in the response.
+     */
+    public boolean isPretty() {
+        return pretty;
+    }
+
+    public static PrettyFormattedBody of(@Nonnull final Object body, final boolean pretty) {
+        return new PrettyFormattedBody(body, pretty);
+    }
+}

--- a/src/main/java/com/commercetools/http/converter/json/PrettyGsonMessageConverter.java
+++ b/src/main/java/com/commercetools/http/converter/json/PrettyGsonMessageConverter.java
@@ -1,0 +1,148 @@
+package com.commercetools.http.converter.json;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.json.GsonHttpMessageConverter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+/**
+ * Custom Gson response message converter to allow JSON pretty print, if requested.
+ * <p>
+ * The class extends default Spring {@link GsonHttpMessageConverter} adding {@link #prettyGson} mapper and processing
+ * {@link PrettyFormattedBody} instances.
+ */
+public class PrettyGsonMessageConverter extends GsonHttpMessageConverter {
+
+    /**
+     * JSON message converter with configured pretty print options, which is used when a response is expected to be
+     * pretty printed.
+     */
+    private final Gson prettyGson;
+
+    /**
+     * @see GsonHttpMessageConverter#jsonPrefix
+     */
+    private String jsonPrefix;
+
+    /**
+     * @param gson       default (minified) JSON mapper. This value is set to {@code super.gson} property.
+     * @param prettyGson pretty configure JSON mapper, which is used if the body expected to be pretty printed
+     */
+    public PrettyGsonMessageConverter(final Gson gson, final Gson prettyGson) {
+        super();
+        this.setGson(gson);
+        this.prettyGson = prettyGson;
+    }
+
+    /**
+     * Because base {@link GsonHttpMessageConverter#jsonPrefix} is private, but is used in overloaded
+     * {@link #writeInternal(Object, Type, HttpOutputMessage)} - we should copy this value.
+     *
+     * @see GsonHttpMessageConverter#setJsonPrefix(String)
+     */
+    @Override
+    public void setJsonPrefix(String jsonPrefix) {
+        super.setJsonPrefix(jsonPrefix);
+        this.jsonPrefix = jsonPrefix;
+    }
+
+    /**
+     * Because base {@link GsonHttpMessageConverter#jsonPrefix} is private, but is used in overloaded
+     * {@link #writeInternal(Object, Type, HttpOutputMessage)} - we should copy this value.
+     *
+     * @see GsonHttpMessageConverter#setPrefixJson(boolean)
+     */
+    @Override
+    public void setPrefixJson(boolean prefixJson) {
+        super.setPrefixJson(prefixJson);
+        this.jsonPrefix = (prefixJson ? ")]}', " : null);
+    }
+
+    /**
+     * Allow response JSON pretty print if {@code objectToWrite} is a {@link PrettyFormattedBody} instance with
+     * <code>{@link PrettyFormattedBody#isPretty() isPretty} == true</code>.
+     *
+     * @param objectToWrite if the value is {@link PrettyFormattedBody} instance with
+     *                      <code>{@link PrettyFormattedBody#isPretty() isPretty} == true</code> - use
+     *                      {@link #prettyGson} for output writing. Otherwise use base
+     *                      {@link GsonHttpMessageConverter#writeInternal(Object, Type, HttpOutputMessage)}
+     * @param type          the type of object to write (may be {@code null})
+     * @param outputMessage the HTTP output message to write to
+     * @throws IOException                     in case of I/O errors
+     * @throws HttpMessageNotWritableException in case of conversion errors
+     */
+    @Override
+    protected void writeInternal(@Nullable final Object objectToWrite,
+                                 @Nullable final Type type,
+                                 @Nonnull final HttpOutputMessage outputMessage)
+            throws IOException, HttpMessageNotWritableException {
+
+        // based on: if objectToWrite is PrettyFormattedBody && isPretty == true => use custom formatter
+        // otherwise - use the default base GsonHttpMessageConverter#writeInternal(Object, Type, HttpOutputMessage)
+
+        final Optional<PrettyFormattedBody> prettyFormatted = Optional.ofNullable(objectToWrite)
+                .filter(o -> o instanceof PrettyFormattedBody)
+                .map(o -> (PrettyFormattedBody) objectToWrite);
+
+        final boolean pretty = prettyFormatted.map(PrettyFormattedBody::isPretty).orElse(false);
+        final Object realObject = prettyFormatted.map(PrettyFormattedBody::getBody).orElse(objectToWrite);
+
+        if (pretty) {
+            // this is basically full copy of super.writeInternal(), but with custom (pretty) gson mapper
+            Charset charset = getCharset(outputMessage.getHeaders());
+            OutputStreamWriter writer = new OutputStreamWriter(outputMessage.getBody(), charset);
+            try {
+                if (this.jsonPrefix != null) {
+                    writer.append(this.jsonPrefix);
+                }
+                if (type != null) {
+                    this.prettyGson.toJson(realObject, type, writer);
+                } else {
+                    this.prettyGson.toJson(realObject, writer);
+                }
+                writer.close();
+            } catch (JsonIOException ex) {
+                throw new HttpMessageNotWritableException("Could not write JSON: " + ex.getMessage(), ex);
+            }
+        } else {
+            // use default writer if isPretty property is not specified
+            super.writeInternal(realObject, type, outputMessage);
+        }
+    }
+
+    /**
+     * To ensure the message converter supports {@link PrettyFormattedBody} instances
+     *
+     * @param clazz response body class
+     * @return <b>true</b> if the {@code clazz} is {@link PrettyFormattedBody} or {@code super.supports(clazz) == true}
+     */
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return PrettyFormattedBody.class.equals(clazz) || super.supports(clazz);
+    }
+
+    /**
+     * Just a copy-paste of {@link GsonHttpMessageConverter#getCharset(HttpHeaders)} because it is private, but used in
+     * {@link #writeInternal(Object, Type, HttpOutputMessage)}
+     *
+     * @param headers output message HTTP headers
+     * @return a charset from the {@code headers} content type or {@link GsonHttpMessageConverter#DEFAULT_CHARSET}
+     * otherwise.
+     */
+    private Charset getCharset(HttpHeaders headers) {
+        if (headers == null || headers.getContentType() == null || headers.getContentType().getCharset() == null) {
+            return DEFAULT_CHARSET;
+        }
+        return headers.getContentType().getCharset();
+    }
+}

--- a/src/main/java/com/commercetools/http/converter/json/PrettyGsonMessageConverter.java
+++ b/src/main/java/com/commercetools/http/converter/json/PrettyGsonMessageConverter.java
@@ -90,12 +90,12 @@ public class PrettyGsonMessageConverter extends GsonHttpMessageConverter {
         // based on: if objectToWrite is PrettyFormattedBody && isPretty == true => use custom formatter
         // otherwise - use the default base GsonHttpMessageConverter#writeInternal(Object, Type, HttpOutputMessage)
 
-        final Optional<PrettyFormattedBody> prettyFormatted = Optional.ofNullable(objectToWrite)
+        Optional<PrettyFormattedBody> prettyFormatted = Optional.ofNullable(objectToWrite)
                 .filter(o -> o instanceof PrettyFormattedBody)
                 .map(o -> (PrettyFormattedBody) objectToWrite);
 
-        final boolean pretty = prettyFormatted.map(PrettyFormattedBody::isPretty).orElse(false);
-        final Object realObject = prettyFormatted.map(PrettyFormattedBody::getBody).orElse(objectToWrite);
+        boolean pretty = prettyFormatted.map(PrettyFormattedBody::isPretty).orElse(false);
+        Object realObject = prettyFormatted.map(PrettyFormattedBody::getBody).orElse(objectToWrite);
 
         if (pretty) {
             // this is basically full copy of super.writeInternal(), but with custom (pretty) gson mapper

--- a/src/test/java/com/commercetools/controller/CommercetoolsHealthControllerIT.java
+++ b/src/test/java/com/commercetools/controller/CommercetoolsHealthControllerIT.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import static com.commercetools.testUtil.TestConstants.MAIN_TEST_TENANT_NAME;
 import static com.commercetools.testUtil.TestConstants.SECOND_TEST_TENANT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -30,17 +31,60 @@ public class CommercetoolsHealthControllerIT {
     @Test
     public void checkHealth() throws Exception {
         // get
-        assertResponse(mockMvc.perform(get("/")));
-        assertResponse(mockMvc.perform(get("/health")));
-        assertResponse(mockMvc.perform(get("/health/")));
+        assertMinifiedResponse(mockMvc.perform(get("")));
+        assertMinifiedResponse(mockMvc.perform(get("/")));
+        assertMinifiedResponse(mockMvc.perform(get("/health")));
+        assertMinifiedResponse(mockMvc.perform(get("/health/")));
 
         // post
-        assertResponse(mockMvc.perform(post("/")));
-        assertResponse(mockMvc.perform(post("/health")));
-        assertResponse(mockMvc.perform(post("/health/")));
+        assertMinifiedResponse(mockMvc.perform(post("")));
+        assertMinifiedResponse(mockMvc.perform(post("/")));
+        assertMinifiedResponse(mockMvc.perform(post("/health")));
+        assertMinifiedResponse(mockMvc.perform(post("/health/")));
     }
 
-    private void assertResponse(ResultActions perform) throws Exception {
+    @Test
+    public void checkHealth_prettyPrint() throws Exception {
+        // get
+        assertPrettyResponse(mockMvc.perform(get("").param("pretty", "")));
+        assertPrettyResponse(mockMvc.perform(get("").param("pretty", "foo")));
+        assertPrettyResponse(mockMvc.perform(get("/").param("pretty", "")));
+        assertPrettyResponse(mockMvc.perform(get("/health").param("pretty", "foo")));
+        assertPrettyResponse(mockMvc.perform(get("/health/").param("pretty", "")));
+        assertPrettyResponse(mockMvc.perform(get("/health/").param("pretty", "foo")));
+
+        // post
+        assertPrettyResponse(mockMvc.perform(post("").param("pretty", "")));
+        assertPrettyResponse(mockMvc.perform(post("").param("pretty", "foo")));
+        assertPrettyResponse(mockMvc.perform(post("/").param("pretty", "")));
+        assertPrettyResponse(mockMvc.perform(post("/health").param("pretty", "foo")));
+        assertPrettyResponse(mockMvc.perform(post("/health/").param("pretty", "")));
+        assertPrettyResponse(mockMvc.perform(post("/health/").param("pretty", "foo")));
+    }
+
+    private void assertMinifiedResponse(ResultActions perform) throws Exception {
+        assertResponseJson(perform);
+        assertThat(perform.andReturn().getResponse().getContentAsString()).hasLineCount(1);
+    }
+
+    private void assertPrettyResponse(ResultActions perform) throws Exception {
+        assertResponseJson(perform);
+
+        final String contentAsString = perform.andReturn().getResponse().getContentAsString();
+
+        // at least one line for tenants, applicationInfo, version and title + 2 lines for root {}
+        assertThat(contentAsString.split("[\n\r]+").length).isGreaterThanOrEqualTo(6);
+
+        // first level keys should be indented at least 1 space
+        assertThat(contentAsString).containsPattern("\\s+\"tenants\"");
+        assertThat(contentAsString).containsPattern("\\s+\"applicationInfo\"");
+
+        //second level "version" and "title" should have at least 2 leading spaces
+        assertThat(contentAsString).containsPattern("\\s{2,}\"version\"");
+        assertThat(contentAsString).containsPattern("\\s{2,}\"title\"");
+    }
+
+    private void assertResponseJson(ResultActions perform) throws Exception {
         perform
                 .andDo(print())
                 .andExpect(status().isOk())

--- a/src/test/java/com/commercetools/http/converter/json/PrettyGsonMessageConverterTest.java
+++ b/src/test/java/com/commercetools/http/converter/json/PrettyGsonMessageConverterTest.java
@@ -1,0 +1,95 @@
+package com.commercetools.http.converter.json;
+
+import com.commercetools.config.ApplicationConfiguration;
+import com.fasterxml.jackson.databind.type.MapType;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.MockHttpOutputMessage;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.commercetools.testUtil.JsonAssertUtil.assertJsonPath;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ApplicationConfiguration.class)
+public class PrettyGsonMessageConverterTest {
+
+    /**
+     * We ensure that default "gsonMessageConverter" bean satisfies default and pretty JSON output.
+     */
+    @Autowired
+    private PrettyGsonMessageConverter gsonMessageConverter;
+
+    @Test
+    public void writeInternal_withHashMapBody_returnsMinifiedJson() throws Exception {
+        MockHttpOutputMessage mockOutput = new MockHttpOutputMessage();
+        gsonMessageConverter.writeInternal(mockResponseMap(), null, mockOutput);
+
+        assertThat(mockOutput.getBodyAsString()).hasLineCount(1);
+        assertWrittenMessage(mockOutput);
+    }
+
+    @Test
+    public void writeInternal_withPrettyFormattedBodyAndPrettyFalse_returnsMinifiedJson() throws Exception {
+        MockHttpOutputMessage mockOutput = new MockHttpOutputMessage();
+        gsonMessageConverter.writeInternal(PrettyFormattedBody.of(mockResponseMap(), false), null, mockOutput);
+        assertThat(mockOutput.getBodyAsString()).hasLineCount(1);
+        assertWrittenMessage(mockOutput);
+    }
+
+    @Test
+    public void writeInternal_withPrettyFormattedBodyAndPrettyTrue_returnsPrettyFormattedJson() throws Exception {
+        MockHttpOutputMessage mockOutput = new MockHttpOutputMessage();
+        gsonMessageConverter.writeInternal(PrettyFormattedBody.of(mockResponseMap(), true), null, mockOutput);
+        assertThat(mockOutput.getBodyAsString().split("[\n\r]+").length).isGreaterThanOrEqualTo(4);
+        assertWrittenMessage(mockOutput);
+    }
+
+    private Map<?, ?> mockResponseMap() {
+        return ImmutableMap.of("aaa", "bbb", "ccc", asList(1, 2, 3));
+    }
+
+    /**
+     * Asserts {@code mockOutput} contains the values from {@link #mockResponseMap()}
+     *
+     * @param mockOutput written {@link MockHttpOutputMessage} where to verify the content
+     */
+    private void assertWrittenMessage(MockHttpOutputMessage mockOutput) {
+        String bodyAsString = mockOutput.getBodyAsString();
+        assertJsonPath(bodyAsString, "$.aaa", is("bbb"));
+        assertJsonPath(bodyAsString, "$.ccc", contains(1, 2, 3));
+        assertJsonPath("{\"arrays\":{\"arrayKey\": [1, 2, 3]}}", "$.arrays.arrayKey", contains(1, 2, 3));
+    }
+
+    @Test
+    public void supports_differentObjects() throws Exception {
+        assertThat(gsonMessageConverter.supports(PrettyFormattedBody.class)).isTrue();
+
+        // verify our overriding has not changed default behavior
+        assertThat(gsonMessageConverter.supports(HashMap.class)).isTrue();
+    }
+
+    @Test
+    public void canWrite_differentObjects() throws Exception {
+        assertThat(gsonMessageConverter.canWrite(PrettyFormattedBody.class, MediaType.APPLICATION_JSON)).isTrue();
+        assertThat(gsonMessageConverter.canWrite(PrettyFormattedBody.class, MediaType.APPLICATION_JSON_UTF8)).isTrue();
+
+        // verify our overriding has not changed default behavior
+        assertThat(gsonMessageConverter.canWrite(HashMap.class, MediaType.APPLICATION_JSON)).isTrue();
+        assertThat(gsonMessageConverter.canWrite(HashMap.class, MediaType.APPLICATION_JSON_UTF8)).isTrue();
+
+        assertThat(gsonMessageConverter.canWrite(MapType.class, HashMap.class, MediaType.APPLICATION_JSON)).isTrue();
+        assertThat(gsonMessageConverter.canWrite(MapType.class, HashMap.class, MediaType.APPLICATION_JSON_UTF8)).isTrue();
+    }
+
+}

--- a/src/test/java/com/commercetools/http/converter/json/PrettyGsonMessageConverterTest.java
+++ b/src/test/java/com/commercetools/http/converter/json/PrettyGsonMessageConverterTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.is;
 public class PrettyGsonMessageConverterTest {
 
     /**
-     * We ensure that default "gsonMessageConverter" bean satisfies default and pretty JSON output.
+     * We ensure that default "gsonMessageConverter
      */
     @Autowired
     private PrettyGsonMessageConverter gsonMessageConverter;

--- a/src/test/java/com/commercetools/testUtil/JsonAssertUtil.java
+++ b/src/test/java/com/commercetools/testUtil/JsonAssertUtil.java
@@ -1,0 +1,28 @@
+package com.commercetools.testUtil;
+
+import com.jayway.jsonpath.JsonPath;
+import org.hamcrest.Matcher;
+import org.springframework.test.util.JsonPathExpectationsHelper;
+
+public final class JsonAssertUtil {
+
+    /**
+     * Assert {@code content} string is JSON-formatted and contains {@code jsonPath} value matching {@code matcher}.
+     * <p>
+     * Example:<pre>
+     * assertJsonPath("{\"key\": \"value\"}", "$.key", is("value"));
+     * assertJsonPath("{\"arrays\":{\"arrayKey\": [1, 2, 3]}}", "$.arrays.arrayKey", contains(1, 2, 3));
+     * </pre>
+     *
+     * @param content  JSON string content
+     * @param jsonPath json path which value to assert.
+     *                 See more at {@link JsonPath#compile(java.lang.String, com.jayway.jsonpath.Predicate...)}
+     * @param matcher  matcher to apply to the value fetched from {@code jsonPath}
+     */
+    public static void assertJsonPath(String content, String jsonPath, Matcher<?> matcher) {
+        (new JsonPathExpectationsHelper(jsonPath)).assertValue(content, matcher);
+    }
+
+    private JsonAssertUtil() {
+    }
+}


### PR DESCRIPTION
Same as in [_commercetools-payone-integration_](https://github.com/commercetools/commercetools-payone-integration/pull/200) before: `health` check is extended to support pretty print for better readability if developers/ops need to verify health response (e.g. tenants lists, application version etc).
The pretty print is activated only when `pretty` URL request parameter is specified.

~Un~fortunately opposite to _commercetools-payone-integration_ service this project is based on highly organized OO Spring framework, so it required a bit more job to make it robust, reliable and convenient, including all potential filtering and pre-processing for the response. 
Thus, the implementation includes:
  - refactored `gsonMessageConverter` bean implementation to use new custom [`PrettyGsonMessageConverter `](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/100/files#diff-4d55ea662f1fd399065885fb0fc15417)
  - [`PrettyGsonMessageConverter `](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/100/files#diff-4d55ea662f1fd399065885fb0fc15417) extends default `GsonHttpMessageConverter` using `prettyGson` mapper additionally to default `gson` mapper. The mapper is chosen based on [`isPretty()`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/100/files#diff-4e4b052a1f7208ed908189f2f003cf18R24) property of the serialized object
  - [`CommercetoolsHealthController`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/100/files#diff-e1d923a05c4b52555104fead9e61dffaL45) is extended to accept optional request parameter `pretty` and based on this value sets `PrettyFormattedBody#isPretty` value.
    - [unit test](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/100/files#diff-4263f5b1d627ab268e186abab8535db8)
    - [integration test](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/100/files#diff-e7e3f5a6bc50c60fb4ccf74b118cc16c)
  - additionally added [JsonAssertUtil](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/100/files#diff-c2e6b952ccece1a9847714bbe15f1301) for convenient json assertions in the tests. Examples of usage: [assertWrittenMessage()](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/100/files#diff-4263f5b1d627ab268e186abab8535db8R67)