### PR TITLE
rename commercetools-paypal-plus-integration-java -> commercetools-paypal-plus-integration

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -2,8 +2,8 @@ FROM java:openjdk-8-jre
 
 MAINTAINER DevOps <ops@commercetools.de>
 
-COPY build/libs/commercetools-paypalplus-integration-java.jar /build/commercetools-paypalplus-integration-java.jar
+COPY build/libs/commercetools-paypalplus-integration.jar /build/commercetools-paypalplus-integration.jar
 
-CMD ["java", "-jar", "/build/commercetools-paypalplus-integration-java.jar"]
+CMD ["java", "-jar", "/build/commercetools-paypalplus-integration.jar"]
 
 EXPOSE 8080

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'commercetools-paypalplus-integration-java'
+rootProject.name = 'commercetools-paypalplus-integration'


### PR DESCRIPTION
Removed "java" from project name