### PR TITLE
#120: remove bashisms

### DIFF
--- a/travis-build/crypt-common.sh
+++ b/travis-build/crypt-common.sh
@@ -6,12 +6,12 @@ PROJECT=professionalserviceslabs
 KEYRING=ps-keyring
 KEY=commercetools-paypal-plus-integration
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 CONFIG_DIR="${SCRIPT_DIR}/configuration"
 PLAIN_FILE="${CONFIG_DIR}/travis-build-settings.sh"
 CIPHER_FILE="${CONFIG_DIR}/travis-build-settings.sh.enc"
 
-function encryptDecrypt() {
+encryptDecrypt() {
     gcloud kms "$1" \
       --project="$PROJECT"\
       --location="global" \

--- a/travis-build/decrypt.sh
+++ b/travis-build/decrypt.sh
@@ -5,12 +5,12 @@
 
 COMMON_SCRIPT="$(dirname "$0")/crypt-common.sh"
 
-if [[ ! -r "$COMMON_SCRIPT" ]] ; then
+if [ ! -r "$COMMON_SCRIPT" ] ; then
     echo "Error: script [${COMMON_SCRIPT}] not found!"
     exit
 fi
 
-source "$COMMON_SCRIPT"
+. "$COMMON_SCRIPT"
 
 encryptDecrypt "decrypt" \
   && chmod u+x "$PLAIN_FILE" \

--- a/travis-build/encrypt.sh
+++ b/travis-build/encrypt.sh
@@ -5,12 +5,12 @@
 
 COMMON_SCRIPT="$(dirname "$0")/crypt-common.sh"
 
-if [[ ! -r "$COMMON_SCRIPT" ]] ; then
+if [ ! -r "$COMMON_SCRIPT" ] ; then
     echo "Error: script [${COMMON_SCRIPT}] not found!"
     exit
 fi
 
-source "$COMMON_SCRIPT"
+. "$COMMON_SCRIPT"
 
 encryptDecrypt "encrypt" \
   && printf "\nEncrypted successfully:\n\n" \


### PR DESCRIPTION
make encrypt/decrypt scripts POSIX compatible. I encountered this problem when i tried to run the app on Linux with default `dash` shell - it won't work properly.

see more in https://wiki.ubuntu.com/DashAsBinSh