### PR TITLE
127 mock integration test configs

### DIFF
--- a/src/main/java/com/commercetools/Application.java
+++ b/src/main/java/com/commercetools/Application.java
@@ -1,7 +1,7 @@
 package com.commercetools;
 
 import com.commercetools.config.ApplicationConfiguration;
-import com.commercetools.config.CtpConfigStartupValidator;
+import com.commercetools.config.CtpConfigStartupConfiguration;
 import com.commercetools.config.PaypalPlusStartupConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Import;
 @SpringBootApplication
 @Import({
         ApplicationConfiguration.class,
-        CtpConfigStartupValidator.class,
+        CtpConfigStartupConfiguration.class,
         PaypalPlusStartupConfiguration.class
 })
 public class Application {

--- a/src/main/java/com/commercetools/config/CtpConfigStartupConfiguration.java
+++ b/src/main/java/com/commercetools/config/CtpConfigStartupConfiguration.java
@@ -1,0 +1,26 @@
+package com.commercetools.config;
+
+import com.commercetools.config.bean.CtpConfigStartupValidator;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Mandatory "blocking" configuration to verify on start-up that CTP custom types exist and have proper fields configured.
+ * <p>
+ * <b>Note:</b> {@link PaypalPlusStartupConfiguration} explicitly depends on this configuration, thus won't proceed
+ * if some CTP types are misconfigured.
+ */
+@Configuration
+public class CtpConfigStartupConfiguration {
+    private final CtpConfigStartupValidator ctpConfigStartupValidator;
+
+    public CtpConfigStartupConfiguration(CtpConfigStartupValidator ctpConfigStartupValidator) {
+        this.ctpConfigStartupValidator = ctpConfigStartupValidator;
+    }
+
+    @PostConstruct
+    private void init() {
+        ctpConfigStartupValidator.validateTypes();
+    }
+}

--- a/src/main/java/com/commercetools/config/PaypalPlusStartupConfiguration.java
+++ b/src/main/java/com/commercetools/config/PaypalPlusStartupConfiguration.java
@@ -26,7 +26,7 @@ import static com.commercetools.payment.constants.Psp.NOTIFICATION_PATH_URL;
 
 // don't run PaypalPlusStartupConfiguration configuration (which will start web hooks registration)
 // unless we are sure CTP projects configuration finished successfully
-@DependsOn("com.commercetools.config.CtpConfigStartupValidator")
+@DependsOn("ctpConfigStartupConfiguration")
 
 @Import(ApplicationConfiguration.class)
 @EnableCaching // used for cacheNames = "PaypalPlusConfigurationCache"

--- a/src/main/java/com/commercetools/config/bean/CtpConfigStartupValidator.java
+++ b/src/main/java/com/commercetools/config/bean/CtpConfigStartupValidator.java
@@ -1,0 +1,25 @@
+package com.commercetools.config.bean;
+
+import io.sphere.sdk.types.Type;
+
+/**
+ * Verify CTP project settings are correct for all configured tenants. If the CTP project settings can't be
+ * automatically synced/updated - the errors are logged and the service exits.
+ *
+ * @see #validateTypes()
+ */
+public interface CtpConfigStartupValidator {
+
+    /**
+     * Verify the CTP {@link Type}s are configured like expected. The implementation compares actual tenant
+     * {@link Type}s with expected types from the embed resources
+     * (see {@link com.commercetools.config.ctpTypes.ExpectedCtpTypes}). If the types could be updated -
+     * the update actions are performed. Otherwise error message is shown and application is finished with error code.
+     * <p>
+     * If neither errors exist nor update actions required - continue application startup.
+     * <p>
+     * The operation is blocking, e.g. the application startup shall not go further before this
+     * validation/synchronization is done completely.
+     */
+    void validateTypes();
+}

--- a/src/main/java/com/commercetools/config/bean/impl/CtpConfigStartupValidatorImpl.java
+++ b/src/main/java/com/commercetools/config/bean/impl/CtpConfigStartupValidatorImpl.java
@@ -39,6 +39,7 @@ public class CtpConfigStartupValidatorImpl implements CtpConfigStartupValidator 
         this.applicationKiller = applicationKiller;
     }
 
+    @Override
     public void validateTypes() {
         try {
             AggregatedCtpTypesValidationResult typesSynchronizationResult =

--- a/src/main/java/com/commercetools/config/bean/impl/CtpConfigStartupValidatorImpl.java
+++ b/src/main/java/com/commercetools/config/bean/impl/CtpConfigStartupValidatorImpl.java
@@ -1,6 +1,7 @@
-package com.commercetools.config;
+package com.commercetools.config.bean.impl;
 
 import com.commercetools.config.bean.ApplicationKiller;
+import com.commercetools.config.bean.CtpConfigStartupValidator;
 import com.commercetools.config.ctpTypes.AggregatedCtpTypesValidationResult;
 import com.commercetools.pspadapter.facade.CtpFacadeFactory;
 import com.commercetools.pspadapter.tenant.TenantConfigFactory;
@@ -8,9 +9,9 @@ import io.sphere.sdk.types.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
-import javax.annotation.PostConstruct;
 
 import static com.commercetools.config.constants.ExitCodes.EXIT_CODE_CTP_TYPE_INCOMPATIBLE;
 import static com.commercetools.config.constants.ExitCodes.EXIT_CODE_CTP_TYPE_VALIDATION_EXCEPTION;
@@ -19,13 +20,8 @@ import static com.commercetools.config.ctpTypes.TenantCtpTypesValidator.validate
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
-/**
- * Verify CTP project settings are correct for all configured tenants. If the CTP project settings can't be
- * automatically synced/updated - the errors are logged and the service exits.
- *
- * @see #validateTypes()
- */
-public class CtpConfigStartupValidator {
+@Component
+public class CtpConfigStartupValidatorImpl implements CtpConfigStartupValidator {
 
     private static final String DOCUMENTATION_REFERENCE =
             "https://github.com/commercetools/commercetools-paypal-plus-integration/blob/master/docs/MigrationGuide.md#to-v03";
@@ -35,27 +31,15 @@ public class CtpConfigStartupValidator {
     private final CtpFacadeFactory ctpFacadeFactory;
 
     @Autowired
-    public CtpConfigStartupValidator(@Nonnull TenantConfigFactory tenantConfigFactory,
-                                     @Nonnull CtpFacadeFactory ctpFacadeFactory,
-                                     @Nonnull ApplicationKiller applicationKiller) {
+    public CtpConfigStartupValidatorImpl(@Nonnull TenantConfigFactory tenantConfigFactory,
+                                         @Nonnull CtpFacadeFactory ctpFacadeFactory,
+                                         @Nonnull ApplicationKiller applicationKiller) {
         this.tenantConfigFactory = tenantConfigFactory;
         this.ctpFacadeFactory = ctpFacadeFactory;
         this.applicationKiller = applicationKiller;
     }
 
-    /**
-     * Verify the CTP {@link Type}s are configured like expected. The implementation compares actual tenant
-     * {@link Type}s with expected types from the embed resources
-     * (see {@link com.commercetools.config.ctpTypes.ExpectedCtpTypes}). If the types could be updated -
-     * the update actions are performed. Otherwise error message is shown and application is finished with error code.
-     * <p>
-     * If neither errors exist nor update actions required - continue application startup.
-     * <p>
-     * The operation is blocking, e.g. the application startup shall not go further before this
-     * validation/synchronization is done completely.
-     */
-    @PostConstruct
-    void validateTypes() {
+    public void validateTypes() {
         try {
             AggregatedCtpTypesValidationResult typesSynchronizationResult =
                     validateAndSyncCtpTypes(ctpFacadeFactory, tenantConfigFactory.getTenantConfigs(), getExpectedCtpTypesFromResources())

--- a/src/main/java/com/commercetools/config/constants/ExitCodes.java
+++ b/src/main/java/com/commercetools/config/constants/ExitCodes.java
@@ -1,6 +1,6 @@
 package com.commercetools.config.constants;
 
-import com.commercetools.config.CtpConfigStartupValidator;
+import com.commercetools.config.bean.impl.CtpConfigStartupValidatorImpl;
 import io.sphere.sdk.types.Type;
 
 /**
@@ -11,14 +11,14 @@ public final class ExitCodes {
     /**
      * If CTP {@link Type}s are incompatible with expected types and can't be automatically synchronized by the service.
      *
-     * @see CtpConfigStartupValidator
+     * @see CtpConfigStartupValidatorImpl
      */
     public static final int EXIT_CODE_CTP_TYPE_INCOMPATIBLE = 129;
 
     /**
      * If unexpected exception occurred in CTP {@link Type}s validation and synchronization.
      *
-     * @see CtpConfigStartupValidator
+     * @see CtpConfigStartupValidatorImpl
      */
     public static final int EXIT_CODE_CTP_TYPE_VALIDATION_EXCEPTION = 130;
 

--- a/src/main/java/com/commercetools/pspadapter/notification/webhook/impl/WebhookContainerImpl.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/webhook/impl/WebhookContainerImpl.java
@@ -55,6 +55,7 @@ public class WebhookContainerImpl implements WebhookContainer {
                         .collect(toMap(WebhookWithTenantName::getTenantName, WebhookWithTenantName::getWebhook)));
     }
 
+    @Override
     public CompletionStage<Webhook> getWebhookCompletionStageByTenantName(@Nonnull String tenantName) {
         return this.tenantNameToWebhookCompletionStage
                 .thenApply(webhookMap -> webhookMap.get(tenantName));

--- a/src/main/java/com/commercetools/pspadapter/notification/webhook/impl/WebhookContainerImpl.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/webhook/impl/WebhookContainerImpl.java
@@ -7,6 +7,7 @@ import com.commercetools.pspadapter.tenant.TenantConfig;
 import com.paypal.api.payments.Webhook;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
@@ -22,6 +23,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 @Component
+@Profile("default") // skip from integration tests
 public class WebhookContainerImpl implements WebhookContainer {
 
     private CompletableFuture<Map<String, Webhook>> tenantNameToWebhookCompletionStage;

--- a/src/main/java/com/commercetools/pspadapter/notification/webhook/impl/WebhookContainerImpl.java
+++ b/src/main/java/com/commercetools/pspadapter/notification/webhook/impl/WebhookContainerImpl.java
@@ -23,7 +23,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 @Component
-@Profile("default") // skip from integration tests
+@Profile("default") // skip this bean creating (and init() method call) in the integration tests
 public class WebhookContainerImpl implements WebhookContainer {
 
     private CompletableFuture<Map<String, Webhook>> tenantNameToWebhookCompletionStage;

--- a/src/test/integration/README.md
+++ b/src/test/integration/README.md
@@ -13,6 +13,8 @@ In this directory we keep complex slow integration tests, which:
   - mocking/spying/stubbing should be used as less as possible, only in cases where some real calls can't be performed
   (for example, when sandbox environment doesn't allow some actions).
   
+  - default testing profile is: **`testIntegrationProfile`** (configured in `application.yml` by default)
+  
 In the build workflow these tests should be executed only in case the unit tests were success.
   
 See [unit tests](/src/test/unit/README.md)

--- a/src/test/integration/java/com/commercetools/context/annotation/PrimaryForTest.java
+++ b/src/test/integration/java/com/commercetools/context/annotation/PrimaryForTest.java
@@ -1,0 +1,23 @@
+package com.commercetools.context.annotation;
+
+import org.springframework.context.annotation.Primary;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that an annotated class is a primary bean for testing (usually integration) purpose.
+ * <p>
+ * The annotation behaves same as {@link Primary} and just a convenient alias name to specify it is a substitute for
+ * the tests. Usually these beans contain some empty or simplified implementation, or some extended counters, captures,
+ * mocks to be asserted and verified during the tests.
+ *
+ * @see Primary
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Primary
+public @interface PrimaryForTest {
+}

--- a/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsCreatePaymentInstallmentIT.java
+++ b/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsCreatePaymentInstallmentIT.java
@@ -8,6 +8,7 @@ import com.paypal.api.payments.PayerInfo;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.PaymentDraftBuilder;
 import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
+import org.bitbucket.radistao.test.annotation.AfterAllMethods;
 import org.bitbucket.radistao.test.annotation.BeforeAllMethods;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.junit.Before;
@@ -51,6 +52,12 @@ public class CommercetoolsCreatePaymentInstallmentIT extends BasePaymentIT {
     @Override
     public void setupBeforeAll() {
         super.setupBeforeAll();
+    }
+
+    @AfterAllMethods
+    @Override
+    public void tearDownAfterAll() {
+        super.tearDownAfterAll();
     }
 
     @Before

--- a/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsCreatePaymentWithExperienceProfileIdIT.java
+++ b/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsCreatePaymentWithExperienceProfileIdIT.java
@@ -8,6 +8,7 @@ import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.PaymentDraftBuilder;
 import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
 import io.sphere.sdk.types.CustomFieldsDraftBuilder;
+import org.bitbucket.radistao.test.annotation.AfterAllMethods;
 import org.bitbucket.radistao.test.annotation.BeforeAllMethods;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.junit.Before;
@@ -60,6 +61,12 @@ public class CommercetoolsCreatePaymentWithExperienceProfileIdIT extends BasePay
     @Override
     public void setupBeforeAll() {
         super.setupBeforeAll();
+    }
+
+    @AfterAllMethods
+    @Override
+    public void tearDownAfterAll() {
+        super.tearDownAfterAll();
     }
 
     @Before

--- a/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsCreatePaymentWithShippingPreferenceIT.java
+++ b/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsCreatePaymentWithShippingPreferenceIT.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.PaymentDraftBuilder;
 import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
 import io.sphere.sdk.types.CustomFieldsDraftBuilder;
+import org.bitbucket.radistao.test.annotation.AfterAllMethods;
 import org.bitbucket.radistao.test.annotation.BeforeAllMethods;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.junit.Before;
@@ -13,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 
 import javax.annotation.Nonnull;
@@ -50,6 +52,12 @@ public class CommercetoolsCreatePaymentWithShippingPreferenceIT extends BasePaym
     @Override
     public void setupBeforeAll() {
         super.setupBeforeAll();
+    }
+
+    @AfterAllMethods
+    @Override
+    public void tearDownAfterAll() {
+        super.tearDownAfterAll();
     }
 
     @Before

--- a/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsCreatePaymentsControllerIT.java
+++ b/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsCreatePaymentsControllerIT.java
@@ -11,6 +11,7 @@ import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.PaymentDraftDsl;
 import io.sphere.sdk.payments.PaymentMethodInfoBuilder;
 import io.sphere.sdk.payments.commands.PaymentCreateCommand;
+import org.bitbucket.radistao.test.annotation.AfterAllMethods;
 import org.bitbucket.radistao.test.annotation.BeforeAllMethods;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.javamoney.moneta.Money;
@@ -20,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.Locale;
@@ -51,6 +53,12 @@ public class CommercetoolsCreatePaymentsControllerIT extends BasePaymentIT {
     @Override
     public void setupBeforeAll() {
         super.setupBeforeAll();
+    }
+
+    @AfterAllMethods
+    @Override
+    public void tearDownAfterAll() {
+        super.tearDownAfterAll();
     }
 
     @Before

--- a/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsExecutePaymentsControllerIT.java
+++ b/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsExecutePaymentsControllerIT.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 import java.util.UUID;

--- a/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsGetPaymentsControllerIT.java
+++ b/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsGetPaymentsControllerIT.java
@@ -3,12 +3,14 @@ package com.commercetools.payment.handler;
 import com.commercetools.Application;
 import com.commercetools.payment.BasePaymentIT;
 import io.sphere.sdk.payments.Payment;
+import org.bitbucket.radistao.test.annotation.AfterAllMethods;
 import org.bitbucket.radistao.test.annotation.BeforeAllMethods;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Optional;
@@ -33,6 +35,12 @@ public class CommercetoolsGetPaymentsControllerIT extends BasePaymentIT {
     @Override
     public void setupBeforeAll() {
         super.setupBeforeAll();
+    }
+
+    @AfterAllMethods
+    @Override
+    public void tearDownAfterAll() {
+        super.tearDownAfterAll();
     }
 
     @Before

--- a/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsPatchPaymentsControllerIT.java
+++ b/src/test/integration/java/com/commercetools/payment/handler/CommercetoolsPatchPaymentsControllerIT.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.carts.commands.CartUpdateCommand;
 import io.sphere.sdk.carts.commands.updateactions.SetBillingAddress;
 import io.sphere.sdk.payments.Payment;
+import org.bitbucket.radistao.test.annotation.AfterAllMethods;
 import org.bitbucket.radistao.test.annotation.BeforeAllMethods;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.javamoney.moneta.Money;
@@ -34,6 +35,12 @@ public class CommercetoolsPatchPaymentsControllerIT extends BasePaymentIT {
     @Override
     public void setupBeforeAll() {
         super.setupBeforeAll();
+    }
+
+    @AfterAllMethods
+    @Override
+    public void tearDownAfterAll() {
+        super.tearDownAfterAll();
     }
 
     @Before

--- a/src/test/integration/java/com/commercetools/payment/notification/CommercetoolsPaymentNotificationControllerIT.java
+++ b/src/test/integration/java/com/commercetools/payment/notification/CommercetoolsPaymentNotificationControllerIT.java
@@ -8,6 +8,7 @@ import io.sphere.sdk.payments.*;
 import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
 import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import io.sphere.sdk.payments.queries.PaymentByIdGet;
+import org.bitbucket.radistao.test.annotation.AfterAllMethods;
 import org.bitbucket.radistao.test.annotation.BeforeAllMethods;
 import org.bitbucket.radistao.test.runner.BeforeAfterSpringTestRunner;
 import org.javamoney.moneta.Money;
@@ -53,6 +54,12 @@ public class CommercetoolsPaymentNotificationControllerIT extends BasePaymentIT 
     @Override
     public void setupBeforeAll() {
         super.setupBeforeAll();
+    }
+
+    @AfterAllMethods
+    @Override
+    public void tearDownAfterAll() {
+        super.tearDownAfterAll();
     }
 
     @Before

--- a/src/test/integration/java/com/commercetools/service/paypalPlus/impl/PaypalPlusPaymentServiceImplIT.java
+++ b/src/test/integration/java/com/commercetools/service/paypalPlus/impl/PaypalPlusPaymentServiceImplIT.java
@@ -4,6 +4,7 @@ import com.commercetools.Application;
 import com.commercetools.pspadapter.APIContextFactory;
 import com.commercetools.service.paypalPlus.PaypalPlusPaymentService;
 import com.paypal.api.payments.*;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/integration/java/com/commercetools/service/paypalPlus/impl/PaypalPlusPaymentServiceImplIT.java
+++ b/src/test/integration/java/com/commercetools/service/paypalPlus/impl/PaypalPlusPaymentServiceImplIT.java
@@ -42,6 +42,7 @@ public class PaypalPlusPaymentServiceImplIT {
     }
 
     @Test
+    @Ignore("The payment method " + CREDIT_CARD + " is not used in Europe and false-fails often, thus ignored so far")
     public void createPseudoCreditCardPayment() throws Exception {
         CreditCard dummyCreditCard = dummyCreditCard();
         final CreditCard storedCreditCard = dummyCreditCard.create(apiContextFactory.createAPIContext());
@@ -65,6 +66,7 @@ public class PaypalPlusPaymentServiceImplIT {
 
 
     @Test
+    @Ignore("The payment method " + CREDIT_CARD + " is not used in Europe and false-fails often, thus ignored so far")
     public void createCreditCardPayment() throws Exception {
         Payment mockPayment = dummyCreditCardSimplePayment();
 

--- a/src/test/integration/java/com/commercetools/test/pspadapter/notification/webhook/EmptyWebhookContainerTestImpl.java
+++ b/src/test/integration/java/com/commercetools/test/pspadapter/notification/webhook/EmptyWebhookContainerTestImpl.java
@@ -22,6 +22,7 @@ public class EmptyWebhookContainerTestImpl implements WebhookContainer {
         LoggerFactory.getLogger(this.getClass().getSimpleName()).info("Skip WebhookContainer initialization");
     }
 
+    @Override
     public CompletionStage<Webhook> getWebhookCompletionStageByTenantName(@Nonnull String tenantName) {
         throw new NotImplementedException("com.commercetools.test.pspadapter.notification.webhook.WebhookContainerTestImpl.getWebhookCompletionStageByTenantName not implemented");
     }

--- a/src/test/integration/java/com/commercetools/test/pspadapter/notification/webhook/EmptyWebhookContainerTestImpl.java
+++ b/src/test/integration/java/com/commercetools/test/pspadapter/notification/webhook/EmptyWebhookContainerTestImpl.java
@@ -1,10 +1,10 @@
 package com.commercetools.test.pspadapter.notification.webhook;
 
+import com.commercetools.context.annotation.PrimaryForTest;
 import com.commercetools.pspadapter.notification.webhook.WebhookContainer;
 import com.paypal.api.payments.Webhook;
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletionStage;
  * Empty default {@link WebhookContainer} implementation for the integration tests.
  */
 @Component
-@Primary // for the tests skip webhooks registration
+@PrimaryForTest // for the tests skip webhooks registration
 public class EmptyWebhookContainerTestImpl implements WebhookContainer {
 
     public EmptyWebhookContainerTestImpl() {

--- a/src/test/integration/java/com/commercetools/test/pspadapter/notification/webhook/EmptyWebhookContainerTestImpl.java
+++ b/src/test/integration/java/com/commercetools/test/pspadapter/notification/webhook/EmptyWebhookContainerTestImpl.java
@@ -1,0 +1,28 @@
+package com.commercetools.test.pspadapter.notification.webhook;
+
+import com.commercetools.pspadapter.notification.webhook.WebhookContainer;
+import com.paypal.api.payments.Webhook;
+import org.apache.commons.lang3.NotImplementedException;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Empty default {@link WebhookContainer} implementation for the integration tests.
+ */
+@Component
+@Primary // for the tests skip webhooks registration
+public class EmptyWebhookContainerTestImpl implements WebhookContainer {
+
+    public EmptyWebhookContainerTestImpl() {
+        //do nothing
+        LoggerFactory.getLogger(this.getClass().getSimpleName()).info("Skip WebhookContainer initialization");
+    }
+
+    public CompletionStage<Webhook> getWebhookCompletionStageByTenantName(@Nonnull String tenantName) {
+        throw new NotImplementedException("com.commercetools.test.pspadapter.notification.webhook.WebhookContainerTestImpl.getWebhookCompletionStageByTenantName not implemented");
+    }
+}

--- a/src/test/integration/java/com/commercetools/testUtil/ctpUtil/CleanupTableUtil.java
+++ b/src/test/integration/java/com/commercetools/testUtil/ctpUtil/CleanupTableUtil.java
@@ -1,5 +1,7 @@
 package com.commercetools.testUtil.ctpUtil;
 
+import com.commercetools.pspadapter.facade.SphereClientFactory;
+import com.commercetools.pspadapter.tenant.TenantConfigFactory;
 import io.sphere.sdk.carts.commands.CartDeleteCommand;
 import io.sphere.sdk.carts.queries.CartQuery;
 import io.sphere.sdk.client.SphereClient;
@@ -47,6 +49,15 @@ public final class CleanupTableUtil {
 
     public static int cleanupTypes(SphereClient sphereClient) {
         return cleanupTable(sphereClient, TypeQuery::of, TypeDeleteCommand::of, "Types");
+    }
+
+    /**
+     * Wipe out all types from all tenants.
+     */
+    public static void cleanupAllTenantsTypes(TenantConfigFactory tenantConfigFactory, SphereClientFactory sphereClientFactory) {
+        tenantConfigFactory.getTenantConfigs().parallelStream()
+                .map(sphereClientFactory::createSphereClient)
+                .forEach(CleanupTableUtil::cleanOrdersCartsPaymentsTypes);
     }
 
     public static void cleanOrdersCartsPayments(SphereClient sphereClient) {

--- a/src/test/integration/java/com/commercetools/testUtil/customTestConfigs/EmptyCtpConfigStartupValidatorTestImpl.java
+++ b/src/test/integration/java/com/commercetools/testUtil/customTestConfigs/EmptyCtpConfigStartupValidatorTestImpl.java
@@ -1,0 +1,20 @@
+package com.commercetools.testUtil.customTestConfigs;
+
+import com.commercetools.config.bean.CtpConfigStartupValidator;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default <i>empty</i> implementation for CTP custom types validation. Should be used in most integration tests,
+ * except those which explicitly depend on CTP custom types.
+ */
+@Component
+@Primary // for most of the integration tests - don't actually validate types
+public class EmptyCtpConfigStartupValidatorTestImpl implements CtpConfigStartupValidator {
+
+    public void validateTypes() {
+        // do nothing in test mode
+        LoggerFactory.getLogger(this.getClass().getSimpleName()).info("Skip CTP types validation");
+    }
+}

--- a/src/test/integration/java/com/commercetools/testUtil/customTestConfigs/EmptyCtpConfigStartupValidatorTestImpl.java
+++ b/src/test/integration/java/com/commercetools/testUtil/customTestConfigs/EmptyCtpConfigStartupValidatorTestImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 @PrimaryForTest // for most of the integration tests - don't actually validate the types
 public class EmptyCtpConfigStartupValidatorTestImpl implements CtpConfigStartupValidator {
 
+    @Override
     public void validateTypes() {
         // do nothing in test mode
         LoggerFactory.getLogger(this.getClass().getSimpleName()).info("Skip CTP types validation");

--- a/src/test/integration/java/com/commercetools/testUtil/customTestConfigs/EmptyCtpConfigStartupValidatorTestImpl.java
+++ b/src/test/integration/java/com/commercetools/testUtil/customTestConfigs/EmptyCtpConfigStartupValidatorTestImpl.java
@@ -1,8 +1,8 @@
 package com.commercetools.testUtil.customTestConfigs;
 
 import com.commercetools.config.bean.CtpConfigStartupValidator;
+import com.commercetools.context.annotation.PrimaryForTest;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 /**
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
  * except those which explicitly depend on CTP custom types.
  */
 @Component
-@Primary // for most of the integration tests - don't actually validate types
+@PrimaryForTest // for most of the integration tests - don't actually validate the types
 public class EmptyCtpConfigStartupValidatorTestImpl implements CtpConfigStartupValidator {
 
     public void validateTypes() {

--- a/src/test/integration/java/com/commercetools/testUtil/mockObjects/MockNotificationValidationInterceptor.java
+++ b/src/test/integration/java/com/commercetools/testUtil/mockObjects/MockNotificationValidationInterceptor.java
@@ -2,13 +2,12 @@ package com.commercetools.testUtil.mockObjects;
 
 import com.commercetools.pspadapter.facade.PaypalPlusFacadeFactory;
 import com.commercetools.pspadapter.notification.validation.NotificationValidationInterceptor;
-import com.commercetools.pspadapter.notification.webhook.impl.WebhookContainerImpl;
 import com.commercetools.pspadapter.tenant.TenantConfigFactory;
+import com.commercetools.test.pspadapter.notification.webhook.EmptyWebhookContainerTestImpl;
 
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Collections;
 
 /**
  * Mock interceptor which just let all the notification requests through
@@ -17,7 +16,7 @@ import java.util.Collections;
 public class MockNotificationValidationInterceptor extends NotificationValidationInterceptor {
 
     public MockNotificationValidationInterceptor(TenantConfigFactory tenantConfigFactory) {
-        super(new WebhookContainerImpl(Collections.emptyList(), new PaypalPlusFacadeFactory(), "http://test.com"), tenantConfigFactory, new PaypalPlusFacadeFactory());
+        super(new EmptyWebhookContainerTestImpl(), tenantConfigFactory, new PaypalPlusFacadeFactory());
     }
 
     @Override

--- a/src/test/integration/resources/config/application.yml.skeleton
+++ b/src/test/integration/resources/config/application.yml.skeleton
@@ -1,6 +1,8 @@
 # settings from test/config/application.yml re-write settings from main/application.yml and test/application.yml
 # rename to application.yml and fill-in to use it in local run/debug mode
 
+spring.profiles.active: testIntegrationProfile
+
 # NOTE: THE INTEGRATION TESTS WILL CLEAN-UP THE CTP PROJECT TABLES
 tenantConfig:
   tenants:


### PR DESCRIPTION
Mock heavy redundant executions in the integration tests:

  - split [`CtpConfigValidator`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-673e6ad0f0803f96afd0ddb4f3ca7252) to [`CtpConfigStartupConfiguration`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-0f02ae2785d03f1f4627487a366f5f15) and [`CtpStartupValidator`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-7ae7a14e360e482ff63618e0223b1875) bean with default implementation [`CtpStartupValidatorImpl`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-673e6ad0f0803f96afd0ddb4f3ca7252). This allows use to substitute default validation in the tests by [`EmptyCtpConfigStartupValidatorTestImpl `](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-96767ca0698f6d42f9da92228bf64536).
    - use [respective explicit bean by name](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-383b51356cbc64ea8e9ecad4aaf944fc) in the tests

  - substitute [`WebhookContainer`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-f36b65d4c9894d037f093578c670cc6b) bean in the tests by [`EmptyWebhookContainerTestImpl `](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-26b60bdf3cf8ce2f159274f1abdaaed1). In the integration tests this bean [is not created at all](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-f36b65d4c9894d037f093578c670cc6bR26) using [Spring profiles feature](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-fe4448048f7b7b08805f262a42a88bf4R16) and activating [`testIntegrationProfile `](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-3998c9be5abb9272bc274409cc5df255R4) for the integration tests

  - introduce [`@PrimaryForTest`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/130/files#diff-65d140e8a0b4773d4a6d3cdd93b6b8e9) annotation to emphasize a bean(config) is replacing default bean(config) in the tests

