### PR TITLE
132 custom description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/.m2
 
 # Please note that if you use a depth of 1 and have a queue of jobs, Travis CI won’t build commits that are in the queue when you push a new commit.
 git:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ which is used for local run/debug, because the integration tests will remove all
         },
         "fields": {
           "reference": "6KF07542JV235932C",
-          "description": "Jersey Herren Blau L SKU-119982930",
+          "description": "Thank you for your order. Order number: 12345",
           "paymentDueDate": "2017-09-27",
           "amount": {
             "centAmount": 200,

--- a/README.md
+++ b/README.md
@@ -88,11 +88,9 @@ which is used for local run/debug, because the integration tests will remove all
                 - [Payment application_context is not documented](https://github.com/paypal/PayPal-REST-API-issues/issues/179)
                 
             - `description` (custom field): if specified - [`Payment#transaction#description`](https://developer.paypal.com/docs/api/payments/#definition-transaction)
-            field is set to this value. Otherwise the description fallback to the string:
-               
-               _Reference: `${payment#custom#reference}`_
-               
-               where `${payment#custom#reference}` - value of _reference_ custom fields
+            field is set to this value. Otherwise the description falls back to the following string: 
+            
+              `Reference: ${payment.custom.fields.reference}`
                
                **Note**: Maximum allowed length according to PayPal Plus API: `127` 
                (including <code>Reference:&nbsp;</code> prefix in case of fallback, so the `reference` custom field

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ which is used for local run/debug, because the integration tests will remove all
             - `amountPlanned`
             - `cancelUrl` (custom field)
             - `successUrl` (custom field)
+            - `reference` (custom field, up to 116 characters)
+            - `languageCode` (custom field)
             - `paymentMethodInfo` needs to be set like this:
             
             ```json
@@ -84,6 +86,17 @@ which is used for local run/debug, because the integration tests will remove all
               Respective issues are created: 
                 - [Payment/Order#applicationContext property is not available](https://github.com/paypal/PayPal-Java-SDK/issues/330#issuecomment-356008914)
                 - [Payment application_context is not documented](https://github.com/paypal/PayPal-REST-API-issues/issues/179)
+                
+            - `description` (custom field): if specified - [`Payment#transaction#description`](https://developer.paypal.com/docs/api/payments/#definition-transaction)
+            field is set to this value. Otherwise the description fallback to the string:
+               
+               _Reference: `${payment#custom#reference}`_
+               
+               where `${payment#custom#reference}` - value of _reference_ custom fields
+               
+               **Note**: Maximum allowed length according to PayPal Plus API: `127` 
+               (including <code>Reference:&nbsp;</code> prefix in case of fallback, so the `reference` custom field
+               must be up to 116 characters long)
             
     1. Backend POSTs CTP payment ID created in the previous step to Paypal-integration. Example: 
         ```
@@ -151,6 +164,7 @@ which is used for local run/debug, because the integration tests will remove all
         },
         "fields": {
           "reference": "6KF07542JV235932C",
+          "description": "Jersey Herren Blau L SKU-119982930",
           "paymentDueDate": "2017-09-27",
           "amount": {
             "centAmount": 200,

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ apply plugin: 'com.adarshr.test-logger'
 targetCompatibility = 1.8
 sourceCompatibility = 1.8
 
-version = '0.3.1-DEV' // this will be replaced by git tag version, if available
+version = '0.4.0-DEV' // this will be replaced by git tag version, if available
 
 apply from: "$rootDir/gradle/version-resolver.gradle"
 apply from: "$rootDir/gradle/docker-build.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ apply plugin: 'com.adarshr.test-logger'
 targetCompatibility = 1.8
 sourceCompatibility = 1.8
 
-version = '0.3.0-DEV' // this will be replaced by git tag version, if available
+version = '0.3.1-DEV' // this will be replaced by git tag version, if available
 
 apply from: "$rootDir/gradle/version-resolver.gradle"
 apply from: "$rootDir/gradle/docker-build.gradle"

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -5,7 +5,7 @@
 - [Migration Guide](#migration-guide)
   - [To v0.2+](#to-v02)
   - [To v0.3+](#to-v03)
-    - [To v0.3.1](#to-v031)
+    - [To v0.4.0](#to-v040)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -93,7 +93,7 @@
     **This approach (remove a field definition before service start) could be applied to any field definition, 
     which has unexpected _required_ field - the field will be re-created automatically by sync CTP types feature.**
 
-### To v0.3.1
+### To v0.4.0
 
 After new service version deployment new custom field will be added automatically to `payment-paypal`
 custom type. After that just specify `description` custom field on payment creation if you want to have

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -5,6 +5,7 @@
 - [Migration Guide](#migration-guide)
   - [To v0.2+](#to-v02)
   - [To v0.3+](#to-v03)
+    - [To v0.3.1](#to-v031)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -91,3 +92,15 @@
     
     **This approach (remove a field definition before service start) could be applied to any field definition, 
     which has unexpected _required_ field - the field will be re-created automatically by sync CTP types feature.**
+
+### To v0.3.1
+
+After new service version deployment new custom field will be added automatically to `payment-paypal`
+custom type. After that just specify `description` custom field on payment creation if you want to have
+custom payment description. Leave the field undefined (or null) 
+to fallback to default description with payment reference:
+
+`Reference: ${payment#custom#reference}`
+
+**Note**: according to [PayPal Plus documentation](https://developer.paypal.com/docs/api/payments/#definition-transaction)
+length of the description must be up to 127 characters, thus length of `reference` must be up to 116 characters.

--- a/src/main/java/com/commercetools/helper/mapper/impl/payment/BasePaymentMapperImpl.java
+++ b/src/main/java/com/commercetools/helper/mapper/impl/payment/BasePaymentMapperImpl.java
@@ -136,7 +136,7 @@ public abstract class BasePaymentMapperImpl implements PaymentMapper {
 
     @Nonnull
     protected String getTransactionDescription(@Nonnull CtpPaymentWithCart paymentWithCartLike) {
-        return "Payment from commercetools Paypal Plus integration service";
+        return paymentWithCartLike.getTransactionDescription();
     }
 
     @Nonnull

--- a/src/main/java/com/commercetools/model/CtpPaymentWithCart.java
+++ b/src/main/java/com/commercetools/model/CtpPaymentWithCart.java
@@ -104,8 +104,14 @@ public class CtpPaymentWithCart {
      * <li>otherwise: String "<i>Reference: <code>${{@link #payment}#custom#reference}</code></i>"
      * (the reference is a mandatory custom field of the payment object)</li>
      * </ol>
+     * <p>
+     * The value is set to <a href="https://developer.paypal.com/docs/api/payments/#definition-transaction">Payment#transaction#description</a>
+     * field.
+     * <p>
+     * <b>Note:</b> {@code Maximum length: 127} (according to PayPal Plus documentation.
      *
      * @return description of the payment/transaction.
+     * @see <a href="https://developer.paypal.com/docs/api/payments/#definition-transaction">PayPal Plus Payment#transaction</a>
      */
     @Nonnull
     public String getTransactionDescription() {

--- a/src/main/java/com/commercetools/model/CtpPaymentWithCart.java
+++ b/src/main/java/com/commercetools/model/CtpPaymentWithCart.java
@@ -97,10 +97,10 @@ public class CtpPaymentWithCart {
     }
 
     /**
-     * Get transaction description for the payment from {@link CtpPaymentCustomFields#DESCRIPTION}
-     * or {@link CtpPaymentCustomFields#REFERENCE} custom fields.
-     * The value is fetched in built the following order:<ol>
-     * <li><code>{@link #payment}#custom#description}</code> string value, if not <code><b>null</b></code></li>
+     * Get transaction description for the payment from {@link CtpPaymentCustomFields#DESCRIPTION description}
+     * or {@link CtpPaymentCustomFields#REFERENCE reference} custom fields.
+     * The value is built the following order:<ol>
+     * <li>entirely <code>{@link #payment}#custom#description</code> string value, if not <code><b>null</b></code></li>
      * <li>otherwise: String "<i>Reference: <code>${{@link #payment}#custom#reference}</code></i>"
      * (the reference is a mandatory custom field of the payment object)</li>
      * </ol>

--- a/src/main/java/com/commercetools/model/CtpPaymentWithCart.java
+++ b/src/main/java/com/commercetools/model/CtpPaymentWithCart.java
@@ -14,6 +14,7 @@ import java.util.*;
 import static com.commercetools.payment.constants.LocaleConstants.DEFAULT_LOCALE;
 import static com.commercetools.payment.constants.ctp.CtpPaymentCustomFields.*;
 import static com.commercetools.util.CustomFieldUtil.*;
+import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -93,6 +94,23 @@ public class CtpPaymentWithCart {
     @Nullable
     public String getShippingPreference() {
         return getCustomFieldEnumKeyOrNull(payment, SHIPPING_PREFERENCE);
+    }
+
+    /**
+     * Get transaction description for the payment from {@link CtpPaymentCustomFields#DESCRIPTION}
+     * or {@link CtpPaymentCustomFields#REFERENCE} custom fields.
+     * The value is fetched in built the following order:<ol>
+     * <li><code>{@link #payment}#custom#description}</code> string value, if not <code><b>null</b></code></li>
+     * <li>otherwise: String "<i>Reference: <code>${{@link #payment}#custom#reference}</code></i>"
+     * (the reference is a mandatory custom field of the payment object)</li>
+     * </ol>
+     *
+     * @return description of the payment/transaction.
+     */
+    @Nonnull
+    public String getTransactionDescription() {
+        return getCustomFieldString(payment, DESCRIPTION)
+                .orElseGet(() -> format("Reference: %s", getCustomFieldStringOrEmpty(payment, REFERENCE)));
     }
 
     /**

--- a/src/main/java/com/commercetools/payment/constants/ctp/CtpPaymentCustomFields.java
+++ b/src/main/java/com/commercetools/payment/constants/ctp/CtpPaymentCustomFields.java
@@ -10,6 +10,7 @@ public final class CtpPaymentCustomFields {
     public static final String SHIPPING_PREFERENCE = "shippingPreference";
 
     public static final String LANGUAGE_CODE_FIELD = "languageCode";
+    public static final String DESCRIPTION = "description";
 
     // payment by invoice
     public static final String REFERENCE = "reference";

--- a/src/main/resources/ctp/types/payment-paypal.json
+++ b/src/main/resources/ctp/types/payment-paypal.json
@@ -41,6 +41,17 @@
       "inputHint": "MultiLine"
     },
     {
+      "name": "description",
+      "label": {
+        "en": "description"
+      },
+      "required": false,
+      "type": {
+        "name": "String"
+      },
+      "inputHint": "MultiLine"
+    },
+    {
       "name": "redirectUrl",
       "label": {
         "en": "redirectUrl"

--- a/src/test/integration/java/com/commercetools/testUtil/TestConstants.java
+++ b/src/test/integration/java/com/commercetools/testUtil/TestConstants.java
@@ -6,7 +6,7 @@ public final class TestConstants {
      */
     public static final String MAIN_TEST_TENANT_NAME = "paypalplus-integration-test";
 
-    public static final String SECOND_TEST_TENANT_NAME = "paypalplus-dev2";
+    public static final String SECOND_TEST_TENANT_NAME = "paypalplus-integration-test-tenant2";
 
     public static final String WEB_PROFILE_NO_ADDRESS_OVERRIDE = "web-profile-no-address-override";
 

--- a/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/DefaultPaymentMapperImplTest.java
+++ b/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/DefaultPaymentMapperImplTest.java
@@ -54,7 +54,7 @@ public class DefaultPaymentMapperImplTest extends BasePaymentMapperTest {
         assertThat(ppPayment.getApplicationContext()).isEqualTo(new ApplicationContext());
 
         Transaction transaction = ppPayment.getTransactions().get(0);
-        assertThat(transaction.getDescription()).isEqualTo("Payment from commercetools Paypal Plus integration service");
+        assertThat(transaction.getDescription()).isEqualTo("Coffee beans for order 12333456");
 
         Amount amount = transaction.getAmount();
 
@@ -109,7 +109,7 @@ public class DefaultPaymentMapperImplTest extends BasePaymentMapperTest {
         assertThat(ppPayment.getApplicationContext()).isEqualTo(new ApplicationContext().setShippingPreference("GET_FROM_FILE"));
 
         Transaction transaction = ppPayment.getTransactions().get(0);
-        assertThat(transaction.getDescription()).isEqualTo("Payment from commercetools Paypal Plus integration service");
+        assertThat(transaction.getDescription()).isEqualTo("Reference: 556677884433");
 
         Amount amount = transaction.getAmount();
         assertThat(amount.getCurrency()).isEqualTo("EUR");

--- a/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/InstallmentPaymentMapperImplTest.java
+++ b/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/InstallmentPaymentMapperImplTest.java
@@ -68,7 +68,7 @@ public class InstallmentPaymentMapperImplTest extends BasePaymentMapperTest {
         assertThat(ppPayment.getApplicationContext()).isEqualTo(new ApplicationContext());
 
         Transaction transaction = ppPayment.getTransactions().get(0);
-        assertThat(transaction.getDescription()).isEqualTo("Payment from commercetools Paypal Plus integration service");
+        assertThat(transaction.getDescription()).isEqualTo("Coffee beans for order 12333456");
 
         Amount amount = transaction.getAmount();
 
@@ -143,7 +143,7 @@ public class InstallmentPaymentMapperImplTest extends BasePaymentMapperTest {
         assertThat(ppPayment.getApplicationContext()).isEqualTo(new ApplicationContext().setShippingPreference("GET_FROM_FILE"));
 
         Transaction transaction = ppPayment.getTransactions().get(0);
-        assertThat(transaction.getDescription()).isEqualTo("Payment from commercetools Paypal Plus integration service");
+        assertThat(transaction.getDescription()).isEqualTo("Reference: 556677884433");
 
         Amount amount = transaction.getAmount();
         assertThat(amount.getCurrency()).isEqualTo("EUR");

--- a/src/test/unit/java/com/commercetools/model/CtpPaymentWithCartTest.java
+++ b/src/test/unit/java/com/commercetools/model/CtpPaymentWithCartTest.java
@@ -101,6 +101,22 @@ public class CtpPaymentWithCartTest {
     }
 
     @Test
+    public void getTransactionDescription() throws Exception {
+        assertThat(paymentWithCart.getTransactionDescription()).isEqualTo("Reference: ");
+        CustomFields customFields = mock(CustomFields.class);
+
+        when(payment.getCustom()).thenReturn(customFields);
+        assertThat(paymentWithCart.getTransactionDescription()).isEqualTo("Reference: ");
+
+        when(customFields.getFieldAsString(REFERENCE)).thenReturn("XXX-999");
+        assertThat(paymentWithCart.getTransactionDescription()).isEqualTo("Reference: XXX-999");
+
+        // ".description" has priority over ".reference"
+        when(customFields.getFieldAsString(DESCRIPTION)).thenReturn("Custom description");
+        assertThat(paymentWithCart.getTransactionDescription()).isEqualTo("Custom description");
+    }
+
+    @Test
     public void getLocalesWithDefault() throws Exception {
         assertThat(paymentWithCart.getLocalesWithDefault()).containsExactly(DEFAULT_LOCALE);
 
@@ -168,4 +184,5 @@ public class CtpPaymentWithCartTest {
         when(cart.getLocale()).thenReturn(forLanguageTag("xx"));
         assertThat(paymentWithCart.getLocalesWithDefault()).containsExactly(CHINESE, forLanguageTag("xx"), DEFAULT_LOCALE);
     }
+
 }

--- a/src/test/unit/resources/mockData/paymentMapper/dummyPaymentForComplexCartWithDiscounts.json
+++ b/src/test/unit/resources/mockData/paymentMapper/dummyPaymentForComplexCartWithDiscounts.json
@@ -16,6 +16,7 @@
     },
     "fields": {
       "reference": "12333456",
+      "description": "Coffee beans for order 12333456",
       "languageCode": "de",
       "cancelUrl": "https://www.sparta.de/cancel/12333456",
       "successUrl": "https://www.sparta.de/success/12333456"


### PR DESCRIPTION
Fixing #132 :
  - add new optional custom field [`description`](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/137/files#diff-b7bad689332c455d0c9308439bb98701R43). The custom type will be updated automatically on the next application deployment.
  - add [transaction description getter](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/137/files#diff-59b607ae22d0f50fc14759490189dea8R99)
  - [tests](https://github.com/commercetools/commercetools-paypal-plus-integration/pull/137/files#diff-a14aa1435def936cd2f687ca24a27926) (unit is enough in this case)