### PR TITLE
Mapped product name along with the SKU to the paypal Item object

### DIFF
--- a/src/main/java/com/commercetools/helper/mapper/impl/payment/BasePaymentMapperImpl.java
+++ b/src/main/java/com/commercetools/helper/mapper/impl/payment/BasePaymentMapperImpl.java
@@ -220,7 +220,7 @@ public abstract class BasePaymentMapperImpl implements PaymentMapper {
 
         MonetaryAmount actualLineItemPrice = lineItem.getPrice().getValue();
         return Stream.of(createPaypalPlusItem(lineItem.getName(), locales, lineItem.getQuantity(), actualLineItemPrice))
-                .map(item -> this.plusSkuProductName(lineItem, locales, item));
+                .map(paypalItem -> this.plusSkuProductName(lineItem, locales, paypalItem));
     }
 
     /**
@@ -253,8 +253,8 @@ public abstract class BasePaymentMapperImpl implements PaymentMapper {
         return createPaypalPlusItem(itemName, locales, dlipfq.getQuantity(), dlipfq.getDiscountedPrice().getValue());
     }
 
-    private Item plusSkuProductName(@Nonnull LineItem lineItem, @Nonnull List<Locale> locales, @Nonnull Item targetItem) {
-        return targetItem.setSku(lineItem.getVariant().getSku())
+    private Item plusSkuProductName(@Nonnull LineItem lineItem, @Nonnull List<Locale> locales, @Nonnull Item paypalItem) {
+        return paypalItem.setSku(lineItem.getVariant().getSku())
                 .setName(lineItem.getName().get(locales));
     }
 

--- a/src/main/java/com/commercetools/helper/mapper/impl/payment/BasePaymentMapperImpl.java
+++ b/src/main/java/com/commercetools/helper/mapper/impl/payment/BasePaymentMapperImpl.java
@@ -211,7 +211,7 @@ public abstract class BasePaymentMapperImpl implements PaymentMapper {
      * @return stream of single item, if discounts are not applied, or multiple items, if discounts are applied.
      * @see #mapCustomLineItemToPaypalPlusItem(CustomLineItem, List)
      */
-    protected Stream<Item> mapLineItemToPaypalPlusItem(@Nonnull LineItem lineItem, @Nonnull List<Locale> locales) {
+    private Stream<Item> mapLineItemToPaypalPlusItem(@Nonnull LineItem lineItem, @Nonnull List<Locale> locales) {
         if (lineItem.getDiscountedPricePerQuantity().size() > 0) {
             return lineItem.getDiscountedPricePerQuantity().stream()
                     .map(dlipfq -> createPaypalPlusItem(lineItem.getName(), locales, dlipfq))
@@ -220,7 +220,7 @@ public abstract class BasePaymentMapperImpl implements PaymentMapper {
 
         MonetaryAmount actualLineItemPrice = lineItem.getPrice().getValue();
         return Stream.of(createPaypalPlusItem(lineItem.getName(), locales, lineItem.getQuantity(), actualLineItemPrice))
-                .map(item -> item.setSku(lineItem.getVariant().getSku()));
+                .map(item -> this.plusSkuProductName(lineItem, locales, item));
     }
 
     /**
@@ -251,6 +251,11 @@ public abstract class BasePaymentMapperImpl implements PaymentMapper {
     protected Item createPaypalPlusItem(@Nonnull LocalizedString itemName, @Nonnull List<Locale> locales,
                                         @Nonnull DiscountedLineItemPriceForQuantity dlipfq) {
         return createPaypalPlusItem(itemName, locales, dlipfq.getQuantity(), dlipfq.getDiscountedPrice().getValue());
+    }
+
+    private Item plusSkuProductName(@Nonnull LineItem lineItem, @Nonnull List<Locale> locales, @Nonnull Item targetItem) {
+        return targetItem.setSku(lineItem.getVariant().getSku())
+                .setName(lineItem.getName().get(locales));
     }
 
     protected Item createPaypalPlusItem(@Nonnull LocalizedString itemName, @Nonnull List<Locale> locales,

--- a/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/BasePaymentMapperTest.java
+++ b/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/BasePaymentMapperTest.java
@@ -4,10 +4,8 @@ import com.paypal.api.payments.Details;
 import com.paypal.api.payments.Item;
 import com.paypal.api.payments.ItemList;
 import com.paypal.api.payments.Transaction;
-import io.sphere.sdk.carts.LineItem;
 
 import java.math.BigDecimal;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,12 +19,12 @@ public class BasePaymentMapperTest {
 
     /**
      * Some items with the same SKU may be duplicated, because they have complex discounted price, thus one line item
-     * is split to several. See
-     * {@link DefaultPaymentMapperImpl#mapLineItemToPaypalPlusItem(LineItem, List)}
+     * is split to several.
      */
-    protected static Item getItemBySkuQuantityPrice(ItemList itemList, String sku, String quantity, String price) {
+    protected static Item getItemBySkuQuantityPrice(ItemList itemList, String sku, String name, String quantity, String price) {
         return itemList.getItems().stream()
                 .filter(item -> sku.equals(item.getSku()))
+                .filter(item -> name.equals(item.getName()))
                 .filter(item -> quantity.equals(item.getQuantity()))
                 .filter(item -> price.equals(item.getPrice()))
                 .findFirst()

--- a/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/DefaultPaymentMapperImplTest.java
+++ b/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/DefaultPaymentMapperImplTest.java
@@ -72,11 +72,11 @@ public class DefaultPaymentMapperImplTest extends BasePaymentMapperTest {
                 .isNull();
 
         assertThat(itemList.getItems().size()).isEqualTo(5);
-        assertItem(getItemBySkuQuantityPrice(itemList, "123454323454667", "1", "115.24"), "Halskette", "1", "115.24", "USD");
-        assertItem(getItemBySkuQuantityPrice(itemList, "123454323454667", "3", "115.24"), "Halskette", "3", "115.24", "USD");
+        assertItem(getItemBySkuQuantityPrice(itemList, "123454323454667", "Halskette", "1", "115.24"), "Halskette", "1", "115.24", "USD");
+        assertItem(getItemBySkuQuantityPrice(itemList, "123454323454667", "Halskette", "3", "115.24"), "Halskette", "3", "115.24", "USD");
         assertItem(getItemBySku(itemList, "2345234523"), "Kasten", "1", "0.00", "USD");
-        assertItem(getItemBySkuQuantityPrice(itemList, "456786468866578", "2", "43.65"), "Ringe", "USD");
-        assertItem(getItemBySkuQuantityPrice(itemList, "456786468866578", "1", "43.64"), "Ringe", "USD");
+        assertItem(getItemBySkuQuantityPrice(itemList, "456786468866578", "Ringe", "2", "43.65"), "Ringe", "USD");
+        assertItem(getItemBySkuQuantityPrice(itemList, "456786468866578", "Ringe", "1", "43.64"), "Ringe", "USD");
 
         assertTransactionAmounts(transaction);
     }

--- a/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/InstallmentPaymentMapperImplTest.java
+++ b/src/test/unit/java/com/commercetools/helper/mapper/impl/payment/InstallmentPaymentMapperImplTest.java
@@ -91,11 +91,11 @@ public class InstallmentPaymentMapperImplTest extends BasePaymentMapperTest {
         assertThat(shippingAddress.getCountryCode()).isEqualTo("DE");
 
         assertThat(itemList.getItems().size()).isEqualTo(5);
-        assertItem(getItemBySkuQuantityPrice(itemList, "123454323454667", "1", "115.24"), "Halskette", "1", "115.24", "USD");
-        assertItem(getItemBySkuQuantityPrice(itemList, "123454323454667", "3", "115.24"), "Halskette", "3", "115.24", "USD");
+        assertItem(getItemBySkuQuantityPrice(itemList, "123454323454667", "Halskette", "1", "115.24"), "Halskette", "1", "115.24", "USD");
+        assertItem(getItemBySkuQuantityPrice(itemList, "123454323454667", "Halskette", "3", "115.24"), "Halskette", "3", "115.24", "USD");
         assertItem(getItemBySku(itemList, "2345234523"), "Kasten", "1", "0.00", "USD");
-        assertItem(getItemBySkuQuantityPrice(itemList, "456786468866578", "2", "43.65"), "Ringe", "USD");
-        assertItem(getItemBySkuQuantityPrice(itemList, "456786468866578", "1", "43.64"), "Ringe", "USD");
+        assertItem(getItemBySkuQuantityPrice(itemList, "456786468866578", "Ringe", "2", "43.65"), "Ringe", "USD");
+        assertItem(getItemBySkuQuantityPrice(itemList, "456786468866578", "Ringe", "1", "43.64"), "Ringe", "USD");
 
         assertTransactionAmounts(transaction);
     }


### PR DESCRIPTION
Added product name when mapping LineItem to Item in Paypal_plus request.

Addresses: https://github.com/commercetools/commercetools-paypal-plus-integration/issues/140