### PR TITLE
unknown exceptions write to interface interaction response

### DIFF
--- a/src/main/java/com/commercetools/exception/IntegrationServiceException.java
+++ b/src/main/java/com/commercetools/exception/IntegrationServiceException.java
@@ -1,5 +1,7 @@
 package com.commercetools.exception;
 
+import com.paypal.api.payments.Error;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -29,5 +31,13 @@ public class IntegrationServiceException extends RuntimeException {
     @Nullable
     public Throwable getCause() {
         return cause;
+    }
+
+    public Error getDetails(){
+        Error error = new Error();
+        error.setName(this.getClass().getName());
+        error.setMessage(this.cause.getMessage());
+
+        return error;
     }
 }

--- a/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandler.java
+++ b/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandler.java
@@ -397,21 +397,26 @@ public class PaymentHandler {
 
         if (throwable instanceof PaypalPlusServiceException) {
             PayPalRESTException restException = ((PaypalPlusServiceException) throwable).getCause();
-
             AddInterfaceInteraction action = createAddInterfaceInteractionAction(restException.getDetails(), RESPONSE);
-            return ctpFacade.getPaymentService().updatePayment(ctpPaymentId, Collections.singletonList(action))
-                    .thenApply(ignore -> PaymentHandleResponse.ofHttpStatusAndErrorMessage(HttpStatus.valueOf(restException.getResponsecode()),
-                            format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, restException.getMessage())));
-        } else if(throwable instanceof IntegrationServiceException){
-            IntegrationServiceException serviceException = (IntegrationServiceException) throwable;
 
+            return writeToResponse(paymentId, paymentIdType, ctpPaymentId, restException.getMessage(), restException.getResponsecode(), action);
+        } else if (throwable instanceof IntegrationServiceException) {
+            IntegrationServiceException serviceException = (IntegrationServiceException) throwable;
             AddInterfaceInteraction action = createAddInterfaceInteractionAction(serviceException.getDetails(), RESPONSE);
-            return ctpFacade.getPaymentService().updatePayment(ctpPaymentId, Collections.singletonList(action))
-                    .thenApply(ignore -> PaymentHandleResponse.ofHttpStatusAndErrorMessage(HttpStatus.INTERNAL_SERVER_ERROR,
-                            format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, serviceException.getMessage())));
+
+            return writeToResponse(paymentId, paymentIdType, ctpPaymentId, serviceException.getMessage(), -1, action);
         }
+        // not identifiable error
         return completedFuture(PaymentHandleResponse.of500InternalServerError(
                 format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, throwable.getMessage())));
+    }
+
+    private CompletionStage<PaymentHandleResponse> writeToResponse(@Nullable String paymentId, @Nullable String paymentIdType,
+                                                                   String ctpPaymentId, String exceptionMessage, int responseCode,
+                                                                   AddInterfaceInteraction action) {
+        return ctpFacade.getPaymentService().updatePayment(ctpPaymentId, Collections.singletonList(action))
+                .thenApply(ignore -> PaymentHandleResponse.ofHttpStatusAndErrorMessage(responseCode != -1 ? HttpStatus.valueOf(responseCode) : HttpStatus.INTERNAL_SERVER_ERROR,
+                        format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, exceptionMessage)));
     }
 
     /**

--- a/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandler.java
+++ b/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandler.java
@@ -399,21 +399,21 @@ public class PaymentHandler {
             PayPalRESTException restException = ((PaypalPlusServiceException) throwable).getCause();
             AddInterfaceInteraction action = createAddInterfaceInteractionAction(restException.getDetails(), RESPONSE);
 
-            return writeToResponse(paymentId, paymentIdType, ctpPaymentId, restException.getMessage(), restException.getResponsecode(), action);
+            return createResponse(paymentId, paymentIdType, ctpPaymentId, restException.getMessage(), restException.getResponsecode(), action);
         } else if (throwable instanceof IntegrationServiceException) {
             IntegrationServiceException serviceException = (IntegrationServiceException) throwable;
             AddInterfaceInteraction action = createAddInterfaceInteractionAction(serviceException.getDetails(), RESPONSE);
 
-            return writeToResponse(paymentId, paymentIdType, ctpPaymentId, serviceException.getMessage(), -1, action);
+            return createResponse(paymentId, paymentIdType, ctpPaymentId, serviceException.getMessage(), -1, action);
         }
         // not identifiable error
         return completedFuture(PaymentHandleResponse.of500InternalServerError(
                 format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, throwable.getMessage())));
     }
 
-    private CompletionStage<PaymentHandleResponse> writeToResponse(@Nullable String paymentId, @Nullable String paymentIdType,
-                                                                   String ctpPaymentId, String exceptionMessage, int responseCode,
-                                                                   AddInterfaceInteraction action) {
+    private CompletionStage<PaymentHandleResponse> createResponse(@Nullable String paymentId, @Nullable String paymentIdType,
+                                                                  String ctpPaymentId, String exceptionMessage, int responseCode,
+                                                                  AddInterfaceInteraction action) {
         return ctpFacade.getPaymentService().updatePayment(ctpPaymentId, Collections.singletonList(action))
                 .thenApply(ignore -> PaymentHandleResponse.ofHttpStatusAndErrorMessage(responseCode != -1 ? HttpStatus.valueOf(responseCode) : HttpStatus.INTERNAL_SERVER_ERROR,
                         format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, exceptionMessage)));

--- a/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandler.java
+++ b/src/main/java/com/commercetools/pspadapter/paymentHandler/impl/PaymentHandler.java
@@ -1,5 +1,6 @@
 package com.commercetools.pspadapter.paymentHandler.impl;
 
+import com.commercetools.exception.IntegrationServiceException;
 import com.commercetools.exception.PaypalPlusException;
 import com.commercetools.exception.PaypalPlusServiceException;
 import com.commercetools.helper.formatter.PaypalPlusFormatter;
@@ -359,11 +360,8 @@ public class PaymentHandler {
                         // the real exception is wrapped inside
                         throwable = throwable.getCause();
                     }
-                    if (throwable instanceof PaypalPlusServiceException) {
-                        PayPalRESTException restException = ((PaypalPlusServiceException) throwable).getCause();
-                        if (restException != null) {
-                            return saveResponseToInterfaceInteraction(paymentId, paymentIdType, restException);
-                        }
+                    if (throwable instanceof PaypalPlusServiceException || throwable instanceof IntegrationServiceException) {
+                        return saveResponseToInterfaceInteraction(paymentId, paymentIdType, throwable);
                     }
                     return completedFuture(PaymentHandleResponse.of400BadRequest(
                             format("%s [%s] can't be processed, details: [%s]", paymentIdType, paymentId, throwable.getMessage())));
@@ -373,7 +371,7 @@ public class PaymentHandler {
 
     private CompletionStage<PaymentHandleResponse> saveResponseToInterfaceInteraction(@Nullable String paymentId,
                                                                                       @Nullable String paymentIdType,
-                                                                                      @Nonnull PayPalRESTException restException) {
+                                                                                      @Nonnull Throwable throwable) {
         CompletionStage<Optional<String>> ctpPaymentIdOptStage = CompletableFuture.completedFuture(Optional.ofNullable(paymentId));
         if (PAYPAL_PLUS_PAYMENT_ID.equals(paymentIdType)) {
             // if it's paypal plus payment id and not ctp payment id,
@@ -386,15 +384,34 @@ public class PaymentHandler {
         CompletionStage<PaymentHandleResponse> paymentHandleResponseStage = ctpPaymentIdOptStage
                 .thenCompose(ctpPaymentIdOpt ->
                         ctpPaymentIdOpt.map(ctpPaymentId -> {
-                            AddInterfaceInteraction action = createAddInterfaceInteractionAction(restException.getDetails(), RESPONSE);
-                            return ctpFacade.getPaymentService().updatePayment(ctpPaymentId, Collections.singletonList(action))
-                                    .thenApply(ignore -> PaymentHandleResponse.ofHttpStatusAndErrorMessage(HttpStatus.valueOf(restException.getResponsecode()),
-                                            format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, restException.getMessage())));
+                            return updatePaymentResponse(paymentId, paymentIdType, throwable, ctpPaymentId);
                         }).orElseGet(() -> CompletableFuture.completedFuture(
                                 PaymentHandleResponse.of404NotFound(format("%s=[%s] is not found.", paymentIdType, paymentId))
                         ))
                 );
         return paymentHandleResponseStage;
+    }
+
+    private CompletionStage<PaymentHandleResponse> updatePaymentResponse(@Nullable String paymentId, @Nullable String paymentIdType,
+                                                                         @Nonnull Throwable throwable, String ctpPaymentId) {
+
+        if (throwable instanceof PaypalPlusServiceException) {
+            PayPalRESTException restException = ((PaypalPlusServiceException) throwable).getCause();
+
+            AddInterfaceInteraction action = createAddInterfaceInteractionAction(restException.getDetails(), RESPONSE);
+            return ctpFacade.getPaymentService().updatePayment(ctpPaymentId, Collections.singletonList(action))
+                    .thenApply(ignore -> PaymentHandleResponse.ofHttpStatusAndErrorMessage(HttpStatus.valueOf(restException.getResponsecode()),
+                            format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, restException.getMessage())));
+        } else if(throwable instanceof IntegrationServiceException){
+            IntegrationServiceException serviceException = (IntegrationServiceException) throwable;
+
+            AddInterfaceInteraction action = createAddInterfaceInteractionAction(serviceException.getDetails(), RESPONSE);
+            return ctpFacade.getPaymentService().updatePayment(ctpPaymentId, Collections.singletonList(action))
+                    .thenApply(ignore -> PaymentHandleResponse.ofHttpStatusAndErrorMessage(HttpStatus.INTERNAL_SERVER_ERROR,
+                            format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, serviceException.getMessage())));
+        }
+        return completedFuture(PaymentHandleResponse.of500InternalServerError(
+                format("%s=[%s] can't be processed, details: [%s]", paymentIdType, paymentId, throwable.getMessage())));
     }
 
     /**


### PR DESCRIPTION
Right now we populate interface interaction with an error message on PaypalPlusServiceException only. We should also do the same on IntegrationServiceException: https://github.com/commercetools/commercetools-paypal-plus-integration/pull/144/files#diff-994292474ab3b7cf7d0c53915c6b408cR65