### PR TITLE
Switch to new dockerhub repo.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: commercetoolsps/commercetools-paypal-plus-integration:${{ steps.vars.outputs.tag }}
+          tags: commercetools/commercetools-paypal-plus-integration:${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
In this pr the deploy pipline was changed, so that the docker Image is now deployed to the new dockerhub repository: https://hub.docker.com/repository/docker/commercetools/commercetools-paypal-plus-integration

